### PR TITLE
Fix Position of Header Logo Image

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -30,7 +30,7 @@ export const Header: React.FC = () => {
   return (
     <div>
       <Navbar />
-      <div className="bg-[#171B38] flex flex-row justify-center py-50 lg:absolute lg:left-0 lg:top-0 lg:pt-20 lg:pl-50">
+      <div className="bg-casper-blue flex flex-row justify-center py-50 lg:absolute lg:left-0 lg:top-0 lg:pt-20 lg:pl-50">
         <Link style={{ textDecoration: 'none' }} to="/">
           <div className="flex flex-row">
             <img className="h-35 xxs:h-50" src={logo} alt="Casper Logo" />


### PR DESCRIPTION
### 🔥 Summary
-We want the navbr items and logo to sit on the same horizontal line for a cleaner look
Before:
<img width="1722" alt="Screen Shot 2022-09-12 at 1 49 05 PM" src="https://user-images.githubusercontent.com/76149236/189756176-0c98001d-be8f-4ec5-a7a0-2a5f2fda745e.png">

After:
<img width="1728" alt="Screen Shot 2022-09-12 at 1 49 38 PM" src="https://user-images.githubusercontent.com/76149236/189756190-6158a67d-f66b-49a3-99f2-19af0fb4e17c.png">

### 😤 Problem / Goals
-The logo image is offset horizontally from the navbar on large screens and it would be cleaner to have them both on the same line

### 🤓 Solution
- Change the positioning to set both on the same horizontal line

### 🗒️ Additional Notes
-Also removed some styles that were being overwritten
