### PR TITLE
Update Spacing for Rows in Details Card

### DIFF
--- a/frontend/src/components/base/DetailCard/DetailCard.tsx
+++ b/frontend/src/components/base/DetailCard/DetailCard.tsx
@@ -4,16 +4,16 @@ import { DetailCardProps } from './DetailCard.types';
 export const DetailCard: React.FC<DetailCardProps> = ({ rows }) => {
   return (
     <section className="w-full m-0 p-0">
-      <div className="w-full bg-[#FFF] shadow-card rounded px-16 pb-0 overflow-x-auto">
+      <div className="w-full bg-[#FFF] shadow-card rounded-lg px-16 pb-0 overflow-x-auto">
         <table className="w-full">
           <tbody>
             {rows.map(({ detailKey, value, key }) => {
               return (
-                <tr key={key} className="h-50">
-                  <td className="border-0 border-b-1 border-light-grey border-solid text-slate-500 whitespace-nowrap pr-32">
+                <tr key={key}>
+                  <td className="h-full py-16 border-0 border-b-1 border-light-grey border-solid text-slate-500 whitespace-nowrap pr-32">
                     {detailKey}
                   </td>
-                  <td className="h-50 border-0 border-b-1 flex items-center border-light-grey border-solid">
+                  <td className="h-full py-16 border-0 border-b-1 flex items-center border-light-grey border-solid">
                     {value}
                   </td>
                 </tr>


### PR DESCRIPTION
### 🔥 Summary
-Adjust the whitespace on rows for a cleaner look

Before: 
<img width="898" alt="Screen Shot 2022-09-13 at 11 21 23 AM" src="https://user-images.githubusercontent.com/76149236/189982245-c8168f52-8876-4c35-9b21-94be97bbabb1.png">

After:
<img width="901" alt="Screen Shot 2022-09-13 at 11 20 39 AM" src="https://user-images.githubusercontent.com/76149236/189982277-c17c43f1-3c1e-4a4c-8435-8d23144ccfbd.png">




### 😤 Problem / Goals
-We want the titles for each row to sit on the top row rather than be centered. This is not an issue for singe lines of text but does not look great for larger chunks of text.

### 🤓 Solution
-Add padding to the rows and align the text to the top rather than center
