### PR TITLE
Add 'reset()' to clear input after hash submission

### DIFF
--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -84,16 +84,15 @@ export const Header: React.FC = () => {
     register,
     handleSubmit,
     reset,
-    formState,
     formState: { errors, isSubmitSuccessful },
   } = useForm<FormValues>({ resolver, defaultValues: { hash: '' } });
   const onSubmit: SubmitHandler<FormValues> = data => navigate(data.path);
 
   useEffect(() => {
-    if (formState.isSubmitSuccessful) {
+    if (isSubmitSuccessful) {
       reset({ hash: '' });
     }
-  }, [formState, isSubmitSuccessful, reset]);
+  }, [isSubmitSuccessful, reset]);
 
   return (
     <header className="w-full bg-casper-blue flex justify-center">


### PR DESCRIPTION
🔥 Summary
We would like the input to clear after user clicks submit button.
😤 Problem / Goals
Field was not clearing after submission
 🤓 Solution
Added react-hook-form's `reset()` function

