### PR TITLE
CI: add middleware npm ci

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -40,18 +40,57 @@ trigger:
 ---
 kind: pipeline
 type: docker
+name: ci-middleware
+
+steps:
+- name: npm install
+  image: casperlabs/node-build-u1804
+  commands:
+  - make middleware-install
+
+- name: npm audit
+  image: casperlabs/node-build-u1804
+  commands:
+  - make middleware-audit
+
+- name: npm lint
+  image: casperlabs/node-build-u1804
+  commands:
+  - make middleware-lint
+
+- name: npm test
+  image: casperlabs/node-build-u1804
+  commands:
+  - make middleware-test
+
+trigger:
+  branch:
+  - dev
+  - "feat-*"
+  - "release-*"
+  event:
+    include:
+    - pull_request
+    - push
+    exclude:
+    - tag
+    - cron
+
+---
+kind: pipeline
+type: docker
 name: nightly-testing
 
 steps:
 - name: npm install
   image: casperlabs/node-build-u1804
   commands:
-  - make frontend-install
+  - make nightly-npm-install
 
 - name: npm test
   image: casperlabs/node-build-u1804
   commands:
-  - make frontend-test
+  - make nightly-npm-tests
 
 - name: notify
   image: plugins/slack

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ frontend-lint:
 frontend-test:
 	cd frontend && npm run test
 
-middleware-all: middleware-install middleware-audit middleware-test
+middleware-all: middleware-install middleware-audit middleware-lint middleware-test
 
 middleware-install:
 	cd middleware && npm install
@@ -48,3 +48,7 @@ middleware-lint:
 
 middleware-test:
 	cd middleware && npm run test
+
+nightly-npm-install: frontend-install middleware-install
+
+nightly-npm-tests: frontend-test middleware-test


### PR DESCRIPTION
### 🔥 Summary
Adds middleware CI to `.drone.yml` 

### 😤 Problem / Goals
- Sync `middleware` CI with `frontend`

### 🤓 Solution
- add middleware ci pipeline
- add middleware to nightly run
