### PR TITLE
Fix Blocks Nav Link

### DIFF
--- a/frontend/src/components/layout/DemoHeader/DemoHeader.tsx
+++ b/frontend/src/components/layout/DemoHeader/DemoHeader.tsx
@@ -85,7 +85,7 @@ const resolver: Resolver<FormValues> = async values => {
 const navItems = [
   {
     title: 'Blocks',
-    path: '/',
+    path: '/blocks',
     key: 'blocks',
   },
   {


### PR DESCRIPTION
### 🔥 Summary
Our navigation for the "Blocks" nav link is broken

### 😤 Problem / Goals
- `navItems` in `<DemoHeader />` was set to `/`

### 🤓 Solution
- update path to `/blocks`
