### PR TITLE
refactor: temporarily hide Deploys Info

### DIFF
--- a/frontend/src/components/layout/Home/DeployInfo/DeploysInfo.tsx
+++ b/frontend/src/components/layout/Home/DeployInfo/DeploysInfo.tsx
@@ -32,6 +32,7 @@ export const DeploysInfo: React.FC = () => (
 );
 
 const DeploysInfoDisplay = styled.section`
+  display: none;
   box-shadow: 0px 0.125rem 0.438 rgba(127, 128, 149, 0.15);
   border-radius: 0.5rem;
   background: #ffffff;


### PR DESCRIPTION
🔥 Summary
Temporarily hide Deploy Info on Home screen until a better solution is created for retrieving the data.
This was requested by ticket #101 Hide Deploys (temporary solution).