### PR TITLE
Feat/add footer w/build and api versions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import React, { StrictMode, useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import useMeasure from 'react-use-measure';
 
-import { Header } from './components';
+import { Footer, Header } from './components';
 import {
   AccountPage,
   BlockPage,
@@ -40,6 +40,7 @@ const App = () => {
             <Route path="/blocks" element={<Blocks />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
+          <Footer />
         </BrowserRouter>
       </div>
     </StrictMode>

--- a/frontend/src/api/rpc-client.test.ts
+++ b/frontend/src/api/rpc-client.test.ts
@@ -896,13 +896,14 @@ describe('rpc-client', () => {
 
   describe('getStatus', () => {
     it('should return network status data', async () => {
-      const version = '1.3.2';
-      const build = 'e2027dbe9';
+      const api = '1.4.10';
+      const build = '1.3.2';
       const chainspecName = 'integration-test';
 
       const mockJsonRpc = {
         getStatus: jest.fn().mockResolvedValue({
-          build_version: `${version}-${build}`,
+          api_version: `${api}`,
+          build_version: `${build}`,
           chainspec_name: chainspecName,
         }),
       };
@@ -912,7 +913,7 @@ describe('rpc-client', () => {
       const currentStatus = await mockRpcClient.getStatus();
 
       expect(mockJsonRpc.getStatus).toHaveBeenCalledTimes(1);
-      expect(currentStatus.version).toBe(version);
+      expect(currentStatus.api).toBe(api);
       expect(currentStatus.build).toBe(build);
       expect(currentStatus.networkName).toBe(chainspecName);
     });

--- a/frontend/src/api/rpc-client.ts
+++ b/frontend/src/api/rpc-client.ts
@@ -363,13 +363,17 @@ export class RpcApi {
 
   getStatus: () => Promise<NetworkStatus> = async () => {
     try {
-      const { build_version: buildVersion, chainspec_name: networkName } =
-        (await this.rpcClient.getStatus()) as GetStatusResultExtended;
+      const {
+        api_version: apiVersion,
+        build_version: buildVersion,
+        chainspec_name: networkName,
+      } = (await this.rpcClient.getStatus()) as GetStatusResultExtended;
 
-      const [version, build] = buildVersion.split('-');
+      const build = buildVersion.slice(0, 5);
+      const api = apiVersion;
 
       return {
-        version,
+        api,
         build,
         networkName,
       };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -55,7 +55,7 @@ export enum BlockSearchType {
 }
 
 export type NetworkStatus = {
-  version: string;
+  api: string;
   build: string;
   networkName: string;
 };

--- a/frontend/src/components/layout/Footer/Footer.tsx
+++ b/frontend/src/components/layout/Footer/Footer.tsx
@@ -1,15 +1,25 @@
+import styled from '@emotion/styled';
 import React from 'react';
+import { colors, fontWeight } from 'src/styled-theme';
 import { useAppSelector, getNetworkStatus } from '../../../store';
 
 export const Footer: React.FC = () => {
-  const { version, build, networkName } = useAppSelector(getNetworkStatus);
+  const { api, build } = useAppSelector(getNetworkStatus);
 
   return (
-    <footer className="block bg-casper-blue text-white text-xs text-center py-25">
-      <p>
-        Casper Node version: {version} ({build})
-      </p>
-      <p>Network Name: {networkName}</p>
-    </footer>
+    <FooterWrapper>
+      <p>Casper Node version: {build}</p>
+      <p>API version : {api}</p>
+    </FooterWrapper>
   );
 };
+
+const FooterWrapper = styled.footer`
+  color: ${colors.cobaltBlue};
+  font-size: clamp(0.9rem, 1.2vw, 1.4rem);
+  font-weight: ${fontWeight.medium};
+  padding: 3rem 0 2rem 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;

--- a/frontend/src/components/layout/Footer/Footer.tsx
+++ b/frontend/src/components/layout/Footer/Footer.tsx
@@ -9,7 +9,7 @@ export const Footer: React.FC = () => {
   return (
     <FooterWrapper>
       <p>Casper Node version: {build}</p>
-      <p>API version : {api}</p>
+      <p>API version: {api}</p>
     </FooterWrapper>
   );
 };
@@ -18,7 +18,7 @@ const FooterWrapper = styled.footer`
   color: ${colors.cobaltBlue};
   font-size: clamp(0.9rem, 1.2vw, 1.4rem);
   font-weight: ${fontWeight.medium};
-  padding: 3rem 0 2rem 0;
+  padding-bottom: 3.5rem;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/layout/Home/BlocksInfo/BlocksInfo.tsx
+++ b/frontend/src/components/layout/Home/BlocksInfo/BlocksInfo.tsx
@@ -57,7 +57,7 @@ const BlockInfoDisplay = styled.section`
 
   @media (min-width: ${breakpoints.lg}) {
     min-width: 45%;
-    margin: 0 7% 4rem 0;
+    margin: 0 4.8rem 4rem 0;
   }
 `;
 

--- a/frontend/src/store/slices/network-slice.ts
+++ b/frontend/src/store/slices/network-slice.ts
@@ -4,14 +4,14 @@ import { Loading } from '../loading.type';
 
 export interface NetworkState {
   status: Loading;
-  version?: string;
+  api?: string;
   build?: string;
   networkName?: string;
 }
 
 const initialState: NetworkState = {
   status: Loading.Idle,
-  version: undefined,
+  api: undefined,
   build: undefined,
   networkName: undefined,
 };
@@ -21,7 +21,6 @@ export const fetchStatus = createAsyncThunk(
   async () => {
     try {
       const status = await casperApi.getStatus();
-
       return status;
     } catch (error: any) {
       throw new Error('An error occurred while fetching status.');
@@ -42,7 +41,7 @@ export const networkSlice = createSlice({
         fetchStatus.fulfilled,
         (state, { payload }: PayloadAction<NetworkStatus>) => {
           state.status = Loading.Complete;
-          state.version = payload.version;
+          state.api = payload.api;
           state.build = payload.build;
           state.networkName = payload.networkName;
         },


### PR DESCRIPTION
<img width="286" alt="Screen Shot 2022-12-13 at 1 35 12 PM" src="https://user-images.githubusercontent.com/88854201/207425924-a4659168-c372-46a0-95fc-dfe825b44973.png">
🔥 Summary
Updated footer component to include API version and build version as requested at https://github.com/casper-network/casper-blockexplorer/issues/97

