### PR TITLE
Version bump

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2022-10-13
+
+### Added
+
+- Basic block explorer views (blocks, peers, block details, account details, deploy details)
+- Block explorer queries directly RPC
+- Basic unit tests 
+- Configurable branding

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2023-01-26
+
+### Added
+
+- Switched `frontend` to use new middleware (`1.1.0`)
+- New table in `/blocks`
+- New more detailed view in `/peers`
+- Number of validators & peers is now visible on the main page
+- Translations mechanisms (`react-i18next`) - translations are in `public/translations`
+
+### Changed
+
+- Redesigned layout of almost all pages
+
 ## [1.0.0] - 2022-10-13
 
 ### Added

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "dependencies": {
         "@babel/core": "^7.16.0",
         "@emotion/react": "^11.10.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.16.0",

--- a/middleware/CHANGELOG.md
+++ b/middleware/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2022-10-13
+
+### Added
+
+- Support for SSE Sidecar (`SIDECAR_REST_URL` & `SIDECAR_EVENTSTREAM_URL` required to enable it)
+- New `/peers` endpoint providing peers statuses (hash of last added block, uptime, ip)
+- New endpoints: `/latest-block`, `/block/:hashOrHeight`, `/status`, `/blocks`, `/deploy/:hash`, `/account/:accountHashOrPublicKey`
+- When it's possible, all of the endpoint support both Sidecar as well as RPC
+- Added cache so number of RPC request is minimized
+
+## [1.0.0] - 2022-10-13
+
+### Added
+
+- Proxy layer that supports list of nodes in case one of them will be dead
+- Basic tests

--- a/middleware/CHANGELOG.md
+++ b/middleware/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2022-10-13
+## [1.1.0] - 2023-01-26
 
 ### Added
 

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "middleware",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "middleware",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middleware",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
### 🔥 Summary
Version bump PR containing:

- version bumps for both `middleware` and `frontend` (`1.1.0`)
- new `CHANGELOG`s