### PR TITLE
Feat-194: Paginate validators page

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -58,6 +58,7 @@
   "peers-currently-online": "Peers currently online",
   "public-key": "Public Key",
   "raw-data": "Raw Data",
+  "rows": "{{count}} rows",
   "search": "Search",
   "select-an-option": "Please select an option and enter a value",
   "select-search-criteria": "Select search criteria",

--- a/app/src/api/api.ts
+++ b/app/src/api/api.ts
@@ -120,11 +120,24 @@ const createApi = (baseUrl: string) => {
       },
     },
     validator: {
-      async getValidators() {
+      async getValidators(
+        tableParams: {
+          sortBy?: string;
+          orderBy?: SortDirection;
+          count?: number;
+          pageNum?: number;
+        } = {},
+      ) {
         type Response = AxiosResponse<ApiData.Validators>;
 
         const response = await middlewareApi.get<Response>(
           '/current-era-validators',
+          {
+            params: {
+              ...tableParams,
+              count: tableParams?.count ?? defaultPagination,
+            },
+          },
         );
 
         if (response.status !== 200) throw new Error(response.statusText);

--- a/app/src/components/base/Table/Table.tsx
+++ b/app/src/components/base/Table/Table.tsx
@@ -202,8 +202,7 @@ const TableBodyItem = styled.td`
 `;
 
 const TableBodyLoadingWrapper = styled.div<{ pageSize: number }>`
-  /* (pageSize + 1) is to account for footer */
-  height: calc(${({ pageSize }) => pageSize + 1} * ${pxToRem(50)});
+  height: calc(${({ pageSize }) => pageSize} * ${pxToRem(50)});
 `;
 
 const LoadingPositionWrapper = styled.div`

--- a/app/src/components/tables/BlockTable/BlocksTable.tsx
+++ b/app/src/components/tables/BlockTable/BlocksTable.tsx
@@ -8,8 +8,8 @@ import styled from '@emotion/styled';
 import {
   getBlocksTableOptions,
   getTotalBlocks,
-  setTableOptions,
-  updatePageNum,
+  setBlocksTableOptions,
+  updateBlocksPageNum,
   useAppSelector,
 } from 'src/store';
 import { SelectOptions } from 'src/components/layout/Header/Partials';
@@ -78,11 +78,11 @@ export const BlocksTable: React.FC<BlocksTableProps> = ({
 
         <NumberedPagination
           tableOptions={blocksTableOptions}
-          setTableOptions={setTableOptions}
+          setTableOptions={setBlocksTableOptions}
           rowCountSelectOptions={rowCountSelectOptions}
           setIsTableLoading={setIsTableLoading}
           totalPages={totalPages}
-          updatePageNum={updatePageNum}
+          updatePageNum={updateBlocksPageNum}
         />
       </BlocksTableHead>
     ),

--- a/app/src/components/tables/BlockTable/BlocksTable.tsx
+++ b/app/src/components/tables/BlockTable/BlocksTable.tsx
@@ -76,7 +76,8 @@ export const BlocksTable: React.FC<BlocksTableProps> = ({
         }),
       },
     ],
-    [],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [t],
   );
 
   useEffect(() => {

--- a/app/src/components/tables/BlockTable/BlocksTable.tsx
+++ b/app/src/components/tables/BlockTable/BlocksTable.tsx
@@ -23,6 +23,12 @@ import { CopyToClipboard, RefreshTimer } from '../../utility';
 import { Table } from '../../base';
 import { NumberedPagination } from '../Pagination/NumberedPagination';
 
+const rowCountSelectOptions: SelectOptions[] | null = [
+  { value: '5', label: '5 rows' },
+  { value: '10', label: '10 rows' },
+  { value: '20', label: '20 rows' },
+];
+
 interface BlocksTableProps {
   readonly total?: number;
   readonly blocks: ApiData.Block[];
@@ -54,31 +60,6 @@ export const BlocksTable: React.FC<BlocksTableProps> = ({
   const totalPages = useMemo(() => {
     return Math.ceil(totalBlocks / blocksTableOptions.pagination.pageSize);
   }, [blocksTableOptions, totalBlocks]);
-
-  const rowCountSelectOptions: SelectOptions[] | null = useMemo(
-    () => [
-      {
-        value: '5',
-        label: t('rows', {
-          count: 5,
-        }),
-      },
-      {
-        value: '10',
-        label: t('rows', {
-          count: 10,
-        }),
-      },
-      {
-        value: '20',
-        label: t('rows', {
-          count: 20,
-        }),
-      },
-    ],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [t],
-  );
 
   useEffect(() => {
     const interval = setInterval(() => {

--- a/app/src/components/tables/BlockTable/BlocksTable.tsx
+++ b/app/src/components/tables/BlockTable/BlocksTable.tsx
@@ -23,12 +23,6 @@ import { CopyToClipboard, RefreshTimer } from '../../utility';
 import { Table } from '../../base';
 import { NumberedPagination } from '../Pagination/NumberedPagination';
 
-const rowCountSelectOptions: SelectOptions[] | null = [
-  { value: '5', label: '5 rows' },
-  { value: '10', label: '10 rows' },
-  { value: '20', label: '20 rows' },
-];
-
 interface BlocksTableProps {
   readonly total?: number;
   readonly blocks: ApiData.Block[];
@@ -60,6 +54,30 @@ export const BlocksTable: React.FC<BlocksTableProps> = ({
   const totalPages = useMemo(() => {
     return Math.ceil(totalBlocks / blocksTableOptions.pagination.pageSize);
   }, [blocksTableOptions, totalBlocks]);
+
+  const rowCountSelectOptions: SelectOptions[] | null = useMemo(
+    () => [
+      {
+        value: '5',
+        label: t('rows', {
+          count: 5,
+        }),
+      },
+      {
+        value: '10',
+        label: t('rows', {
+          count: 10,
+        }),
+      },
+      {
+        value: '20',
+        label: t('rows', {
+          count: 20,
+        }),
+      },
+    ],
+    [],
+  );
 
   useEffect(() => {
     const interval = setInterval(() => {

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -49,7 +49,7 @@ export const ValidatorTable: React.FC<ValidatorTableProps> = ({
         }),
       },
     ],
-    [],
+    [t],
   );
 
   const validatorsTableOptions = useAppSelector(getValidatorsTableOptions);

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -2,18 +2,47 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from '@emotion/styled';
 import { ColumnDef } from '@tanstack/react-table';
-import { colors, fontWeight } from 'src/styled-theme';
+import { colors, fontWeight, pxToRem } from 'src/styled-theme';
 import { ValidatorWeight } from 'casper-js-sdk';
+import {
+  getTotalEraValidators,
+  getValidatorsTableOptions,
+  setValidatorTableOptions,
+  updateValidatorPageNum,
+  useAppSelector,
+} from 'src/store';
+import { SelectOptions } from 'src/components/layout/Header/Partials';
 import { Table } from '../../base';
+import { NumberedPagination } from '../Pagination';
+
+const rowCountSelectOptions: SelectOptions[] | null = [
+  { value: '5', label: '5 rows' },
+  { value: '10', label: '10 rows' },
+  { value: '20', label: '20 rows' },
+];
 
 interface ValidatorTableProps {
   readonly validators: ValidatorWeight[];
+  isTableLoading: boolean;
+  setIsTableLoading: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const ValidatorTable: React.FC<ValidatorTableProps> = ({
   validators,
+  isTableLoading,
+  setIsTableLoading,
 }) => {
   const { t } = useTranslation();
+
+  const validatorsTableOptions = useAppSelector(getValidatorsTableOptions);
+  const totalEraValidators = useAppSelector(getTotalEraValidators);
+
+  const totalPages = useMemo(() => {
+    return Math.ceil(
+      totalEraValidators / validatorsTableOptions.pagination.pageSize,
+    );
+  }, [validatorsTableOptions, totalEraValidators]);
+
   const columns = useMemo<ColumnDef<ValidatorWeight>[]>(
     () => [
       {
@@ -36,6 +65,14 @@ export const ValidatorTable: React.FC<ValidatorTableProps> = ({
       <HeadValue>
         {validators.length} {t('total-rows')}
       </HeadValue>
+      <NumberedPagination
+        tableOptions={validatorsTableOptions}
+        setTableOptions={setValidatorTableOptions}
+        rowCountSelectOptions={rowCountSelectOptions}
+        setIsTableLoading={setIsTableLoading}
+        totalPages={totalPages}
+        updatePageNum={updateValidatorPageNum}
+      />
     </ValidatorTableHead>
   );
 
@@ -44,12 +81,17 @@ export const ValidatorTable: React.FC<ValidatorTableProps> = ({
       header={header}
       columns={columns}
       data={validators}
+      tableBodyLoading={isTableLoading}
     />
   );
 };
 
 const ValidatorTableHead = styled.div`
   display: flex;
+  min-width: ${pxToRem(900)};
+  justify-content: space-between;
+  align-items: center;
+  color: ${colors.darkSupporting};
 `;
 
 const HeadLabel = styled.p`

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -52,11 +52,13 @@ export const ValidatorTable: React.FC<ValidatorTableProps> = ({
         header: `${t('public-key')}`,
         accessorKey: 'public_key',
         enableSorting: false,
+        minSize: 750,
       },
       {
         header: `${t('weight')}`,
         accessorKey: 'weight',
         enableSorting: false,
+        minSize: 400,
       },
     ],
     [t],

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -15,12 +15,6 @@ import { SelectOptions } from 'src/components/layout/Header/Partials';
 import { Table } from '../../base';
 import { NumberedPagination } from '../Pagination';
 
-const rowCountSelectOptions: SelectOptions[] | null = [
-  { value: '5', label: '5 rows' },
-  { value: '10', label: '10 rows' },
-  { value: '20', label: '20 rows' },
-];
-
 interface ValidatorTableProps {
   readonly validators: ValidatorWeight[];
   isTableLoading: boolean;
@@ -33,6 +27,30 @@ export const ValidatorTable: React.FC<ValidatorTableProps> = ({
   setIsTableLoading,
 }) => {
   const { t } = useTranslation();
+
+  const rowCountSelectOptions: SelectOptions[] | null = useMemo(
+    () => [
+      {
+        value: '5',
+        label: t('rows', {
+          count: 5,
+        }),
+      },
+      {
+        value: '10',
+        label: t('rows', {
+          count: 10,
+        }),
+      },
+      {
+        value: '20',
+        label: t('rows', {
+          count: 20,
+        }),
+      },
+    ],
+    [],
+  );
 
   const validatorsTableOptions = useAppSelector(getValidatorsTableOptions);
   const totalEraValidators = useAppSelector(getTotalEraValidators);

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -83,8 +83,7 @@ export const ValidatorTable: React.FC<ValidatorTableProps> = ({
       header={header}
       columns={columns}
       data={validators}
-      // TODO: figure out a blank footer
-      footer={<>hello</>}
+      footer={<ValidatorFooter />}
       tableBodyLoading={isTableLoading}
       currentPageSize={validatorsTableOptions.pagination.pageSize}
     />
@@ -97,6 +96,10 @@ const ValidatorTableHead = styled.div`
   justify-content: space-between;
   align-items: center;
   color: ${colors.darkSupporting};
+`;
+
+const ValidatorFooter = styled.div`
+  height: ${pxToRem(50)};
 `;
 
 const HeadValue = styled.p`

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from '@emotion/styled';
 import { ColumnDef } from '@tanstack/react-table';
-import { colors, fontWeight, pxToRem } from 'src/styled-theme';
+import { colors, pxToRem } from 'src/styled-theme';
 import { ValidatorWeight } from 'casper-js-sdk';
 import {
   getTotalEraValidators,
@@ -37,6 +37,9 @@ export const ValidatorTable: React.FC<ValidatorTableProps> = ({
   const validatorsTableOptions = useAppSelector(getValidatorsTableOptions);
   const totalEraValidators = useAppSelector(getTotalEraValidators);
 
+  console.log({ validatorsTableOptions });
+  console.log({ totalEraValidators });
+
   const totalPages = useMemo(() => {
     return Math.ceil(
       totalEraValidators / validatorsTableOptions.pagination.pageSize,
@@ -61,9 +64,8 @@ export const ValidatorTable: React.FC<ValidatorTableProps> = ({
 
   const header = (
     <ValidatorTableHead>
-      <HeadLabel>{t('currently-online')}</HeadLabel>
       <HeadValue>
-        {validators.length} {t('total-rows')}
+        {totalEraValidators} {t('total-rows')}
       </HeadValue>
       <NumberedPagination
         tableOptions={validatorsTableOptions}
@@ -81,7 +83,10 @@ export const ValidatorTable: React.FC<ValidatorTableProps> = ({
       header={header}
       columns={columns}
       data={validators}
+      // TODO: figure out a blank footer
+      footer={<>hello</>}
       tableBodyLoading={isTableLoading}
+      currentPageSize={validatorsTableOptions.pagination.pageSize}
     />
   );
 };
@@ -94,12 +99,6 @@ const ValidatorTableHead = styled.div`
   color: ${colors.darkSupporting};
 `;
 
-const HeadLabel = styled.p`
-  color: ${colors.black};
-  font-weight: ${fontWeight.bold};
-  padding-right: 2rem;
-`;
-
 const HeadValue = styled.p`
-  color: ${colors.lightSupporting};
+  color: ${colors.darkSupporting};
 `;

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -37,9 +37,6 @@ export const ValidatorTable: React.FC<ValidatorTableProps> = ({
   const validatorsTableOptions = useAppSelector(getValidatorsTableOptions);
   const totalEraValidators = useAppSelector(getTotalEraValidators);
 
-  console.log({ validatorsTableOptions });
-  console.log({ totalEraValidators });
-
   const totalPages = useMemo(() => {
     return Math.ceil(
       totalEraValidators / validatorsTableOptions.pagination.pageSize,

--- a/app/src/pages/Blocks.tsx
+++ b/app/src/pages/Blocks.tsx
@@ -15,7 +15,7 @@ import {
   fetchBlocks,
   getTotalBlocks,
   getBlocksTableOptions,
-  updateSorting,
+  updateBlocksSorting,
 } from 'src/store';
 import { SortingState } from '@tanstack/react-table';
 
@@ -86,7 +86,7 @@ export const Blocks: React.FC = () => {
         onSortingChange={() => {
           setIsTableLoading(true);
           dispatch(
-            updateSorting({
+            updateBlocksSorting({
               sortBy: 'height',
               order:
                 blocksTableOptions.sorting.order === 'desc' ? 'asc' : 'desc',

--- a/app/src/pages/Validators.tsx
+++ b/app/src/pages/Validators.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   fetchValidators,
@@ -16,6 +16,8 @@ import {
 } from '../components';
 
 export const Validators: React.FC = () => {
+  const [isTableLoading, setIsTableLoading] = useState(false);
+
   const { t } = useTranslation();
 
   const dispatch = useAppDispatch();
@@ -35,7 +37,13 @@ export const Validators: React.FC = () => {
     <PageWrapper isLoading={isLoading}>
       <PageHead pageTitle={pageTitle} />
       <GradientHeading type="h2">{t('active-validators')}</GradientHeading>
-      {validators && <ValidatorTable validators={validators} />}
+      {validators && (
+        <ValidatorTable
+          validators={validators}
+          isTableLoading={isTableLoading}
+          setIsTableLoading={setIsTableLoading}
+        />
+      )}
     </PageWrapper>
   );
 };

--- a/app/src/pages/Validators.tsx
+++ b/app/src/pages/Validators.tsx
@@ -30,7 +30,7 @@ export const Validators: React.FC = () => {
 
   useEffect(() => {
     dispatch(fetchCurrentEraValidatorStatus());
-  }, []);
+  }, [dispatch]);
 
   useEffect(() => {
     dispatch(fetchValidators(validatorsTableOptions));

--- a/app/src/pages/Validators.tsx
+++ b/app/src/pages/Validators.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
+  fetchCurrentEraValidatorStatus,
   fetchValidators,
   getValidatorLoadingStatus,
   getValidators,
+  getValidatorsTableOptions,
   Loading,
   useAppDispatch,
   useAppSelector,
@@ -22,14 +24,27 @@ export const Validators: React.FC = () => {
 
   const dispatch = useAppDispatch();
 
-  useEffect(() => {
-    dispatch(fetchValidators());
-  }, [dispatch]);
-
   const validators = useAppSelector(getValidators);
+  const validatorsTableOptions = useAppSelector(getValidatorsTableOptions);
   const validatorsLoadingStatus = useAppSelector(getValidatorLoadingStatus);
 
-  const isLoading = validatorsLoadingStatus !== Loading.Complete;
+  useEffect(() => {
+    dispatch(fetchCurrentEraValidatorStatus());
+  }, []);
+
+  useEffect(() => {
+    dispatch(fetchValidators(validatorsTableOptions));
+  }, [dispatch, validatorsTableOptions]);
+
+  useEffect(() => {
+    if (isTableLoading) {
+      setIsTableLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [validators]);
+
+  const isLoading =
+    validatorsLoadingStatus !== Loading.Complete && !validators.length;
 
   const pageTitle = `${t('validators')}`;
 

--- a/app/src/store/selectors/validator-selectors.ts
+++ b/app/src/store/selectors/validator-selectors.ts
@@ -21,5 +21,5 @@ export const getValidatorsTableOptions = (state: RootState) => {
 };
 
 export const getTotalEraValidators = (state: RootState) => {
-  return state.validator.validators.length;
+  return state.validator.currentEraValidatorStatus?.validatorsCount ?? 0;
 };

--- a/app/src/store/selectors/validator-selectors.ts
+++ b/app/src/store/selectors/validator-selectors.ts
@@ -15,3 +15,11 @@ export const getCurrentEraValidatorStatus = (state: RootState) => {
 export const getCurrentEraValidatorStatusStatus = (state: RootState) => {
   return state.validator.status;
 };
+
+export const getValidatorsTableOptions = (state: RootState) => {
+  return state.validator.tableOptions;
+};
+
+export const getTotalEraValidators = (state: RootState) => {
+  return state.validator.validators.length;
+};

--- a/app/src/store/slices/block-slice.ts
+++ b/app/src/store/slices/block-slice.ts
@@ -113,16 +113,16 @@ export const blockSlice = createSlice({
         return { ...block, timeSince };
       });
     },
-    setTableOptions: (
+    setBlocksTableOptions: (
       state,
       action: PayloadAction<BlockState['tableOptions']>,
     ) => {
       state.tableOptions = action.payload;
     },
-    updatePageNum: (state, action: PayloadAction<number>) => {
+    updateBlocksPageNum: (state, action: PayloadAction<number>) => {
       state.tableOptions.pagination.pageNum += action.payload;
     },
-    updateSorting: (
+    updateBlocksSorting: (
       state,
       action: PayloadAction<BlockState['tableOptions']['sorting']>,
     ) => {
@@ -175,7 +175,7 @@ export const blockSlice = createSlice({
 
 export const {
   refreshBlockTimes,
-  setTableOptions,
-  updatePageNum,
-  updateSorting,
+  setBlocksTableOptions,
+  updateBlocksPageNum,
+  updateBlocksSorting,
 } = blockSlice.actions;

--- a/app/src/store/slices/validator-slice.ts
+++ b/app/src/store/slices/validator-slice.ts
@@ -33,9 +33,17 @@ const initialState: ValidatorState = {
 
 export const fetchValidators = createAsyncThunk(
   'rpcClient/fetchValidators',
-  async () => {
+  async ({
+    pagination: { pageSize, pageNum },
+    sorting: { sortBy, order },
+  }: ValidatorState['tableOptions']) => {
     try {
-      const validators = await middlewareServiceApi.validator.getValidators();
+      const validators = await middlewareServiceApi.validator.getValidators({
+        sortBy,
+        orderBy: order,
+        count: pageSize,
+        pageNum,
+      });
 
       return validators;
     } catch (error: any) {

--- a/app/src/store/slices/validator-slice.ts
+++ b/app/src/store/slices/validator-slice.ts
@@ -1,19 +1,34 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import { ValidatorWeight } from 'casper-js-sdk';
 import { ApiData } from 'src/api/types';
+import { loadConfig } from 'src/utils';
 import { middlewareServiceApi } from '../../api';
 import { Loading } from '../loading.type';
+import { TableOptions } from '../types';
+
+const { defaultPagination } = loadConfig();
 
 export interface ValidatorState {
   status: Loading;
   validators: ValidatorWeight[];
   currentEraValidatorStatus: ApiData.CurrentEraValidatorStatus | null;
+  tableOptions: TableOptions;
 }
 
 const initialState: ValidatorState = {
   status: Loading.Idle,
   validators: [],
   currentEraValidatorStatus: null,
+  tableOptions: {
+    pagination: {
+      pageSize: defaultPagination,
+      pageNum: 1,
+    },
+    sorting: {
+      sortBy: '',
+      order: 'desc',
+    },
+  },
 };
 
 export const fetchValidators = createAsyncThunk(
@@ -46,7 +61,23 @@ export const fetchCurrentEraValidatorStatus = createAsyncThunk(
 export const validatorSlice = createSlice({
   name: 'validator',
   initialState,
-  reducers: {},
+  reducers: {
+    setValidatorTableOptions: (
+      state,
+      action: PayloadAction<ValidatorState['tableOptions']>,
+    ) => {
+      state.tableOptions = action.payload;
+    },
+    updateValidatorPageNum: (state, action: PayloadAction<number>) => {
+      state.tableOptions.pagination.pageNum += action.payload;
+    },
+    updateValidatorSorting: (
+      state,
+      action: PayloadAction<ValidatorState['tableOptions']['sorting']>,
+    ) => {
+      state.tableOptions.sorting = action.payload;
+    },
+  },
   extraReducers(builder) {
     builder
       .addCase(fetchValidators.pending, state => {
@@ -80,3 +111,9 @@ export const validatorSlice = createSlice({
       });
   },
 });
+
+export const {
+  setValidatorTableOptions,
+  updateValidatorPageNum,
+  updateValidatorSorting,
+} = validatorSlice.actions;


### PR DESCRIPTION
### 🔥 Summary
Paginate validators page: https://github.com/casper-network/casper-blockexplorer-frontend/issues/194

### 😤 Problem / Goals
- Validators page is currently unpaginated

### 🤓 Solution
- Use the same `NumberedPagination` component from blocks table to apply to validators
- Update redux to add pagination methods
- Update middleware to work with pagination

### 🗒️ Additional Notes
- Middleware updates need to be merged simultaneously: https://github.com/casper-network/casper-blockexplorer-middleware/pull/18 
