### PR TITLE
Feat-211: update validators table - styles, formatting and sorting

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -18,6 +18,7 @@
   "connected-peers": "Connected Peers",
   "connected-peers-online": "Connected Peers online",
   "cost": "Cost",
+  "cspr": "CSPR",
   "current-era": "Current Era",
   "currently-online": "Currently online",
   "datetime": "Date Time",

--- a/app/src/components/base/Table/Table.tsx
+++ b/app/src/components/base/Table/Table.tsx
@@ -61,16 +61,16 @@ export function Table<T extends unknown>({
       <StyledTable>
         <TableHead>
           {getHeaderGroups().map(headerGroup => {
-            console.log({ headerGroup });
+            // console.log({ headerGroup });
 
             return (
               <TableHeader key={headerGroup.id}>
                 {headerGroup.headers.map(header => {
-                  console.log({ header });
+                  // console.log({ header });
                   const isSorted = header.column.getIsSorted();
                   const canSort = header.column.getCanSort();
                   const content = header.getContext().column.id;
-                  console.log({ isSorted, canSort, content });
+                  // console.log({ isSorted, canSort, content });
 
                   return (
                     <Th
@@ -231,6 +231,7 @@ const SortIconWrapper = styled.div<{ disabled?: boolean }>`
   justify-content: center;
   align-items: center;
   border-radius: ${pxToRem(5)};
+  margin-right: 0.5rem;
 
   * {
     color: white;

--- a/app/src/components/base/Table/Table.tsx
+++ b/app/src/components/base/Table/Table.tsx
@@ -61,16 +61,11 @@ export function Table<T extends unknown>({
       <StyledTable>
         <TableHead>
           {getHeaderGroups().map(headerGroup => {
-            // console.log({ headerGroup });
-
             return (
               <TableHeader key={headerGroup.id}>
                 {headerGroup.headers.map(header => {
-                  // console.log({ header });
                   const isSorted = header.column.getIsSorted();
                   const canSort = header.column.getCanSort();
-                  const content = header.getContext().column.id;
-                  // console.log({ isSorted, canSort, content });
 
                   return (
                     <Th
@@ -104,6 +99,7 @@ export function Table<T extends unknown>({
                                 </SortIconWrapper>
                               ),
                             }[header.column.getIsSorted() as string] ?? null}
+                            {canSort && !isSorted && <CanSortWrapper />}
                           </span>
                         </>
                       )}
@@ -247,4 +243,15 @@ const SortIcon = styled.img`
   width: ${pxToRem(12)};
   height: ${pxToRem(12)};
   margin: 0;
+`;
+
+const CanSortWrapper = styled.div`
+  height: ${pxToRem(27)};
+  width: ${pxToRem(27)};
+  background-color: #02115f;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: ${pxToRem(5)};
+  margin-right: 0.5rem;
 `;

--- a/app/src/components/base/Table/Table.tsx
+++ b/app/src/components/base/Table/Table.tsx
@@ -60,47 +60,59 @@ export function Table<T extends unknown>({
       <Header>{header}</Header>
       <StyledTable>
         <TableHead>
-          {getHeaderGroups().map(headerGroup => (
-            <TableHeader key={headerGroup.id}>
-              {headerGroup.headers.map(header => (
-                <Th
-                  key={header.id}
-                  colSpan={header.colSpan}
-                  style={{ width: header.getSize() }}
-                  sortable={header.column.getCanSort()}
-                  onClick={() =>
-                    header.column.getCanSort()
-                      ? header.column.toggleSorting(
-                          header.column.getIsSorted() === 'asc',
-                        )
-                      : undefined
-                  }>
-                  {header.isPlaceholder ? null : (
-                    <>
-                      {flexRender(
-                        header.column.columnDef.header,
-                        header.getContext(),
+          {getHeaderGroups().map(headerGroup => {
+            console.log({ headerGroup });
+
+            return (
+              <TableHeader key={headerGroup.id}>
+                {headerGroup.headers.map(header => {
+                  console.log({ header });
+                  const isSorted = header.column.getIsSorted();
+                  const canSort = header.column.getCanSort();
+                  const content = header.getContext().column.id;
+                  console.log({ isSorted, canSort, content });
+
+                  return (
+                    <Th
+                      key={header.id}
+                      colSpan={header.colSpan}
+                      style={{ width: header.getSize() }}
+                      sortable={header.column.getCanSort()}
+                      onClick={() =>
+                        header.column.getCanSort()
+                          ? header.column.toggleSorting(
+                              header.column.getIsSorted() === 'asc',
+                            )
+                          : undefined
+                      }>
+                      {header.isPlaceholder ? null : (
+                        <>
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                          <span>
+                            {{
+                              asc: (
+                                <SortIconWrapper>
+                                  <SortIcon src={upIcon} alt="sort-asc" />
+                                </SortIconWrapper>
+                              ),
+                              desc: (
+                                <SortIconWrapper>
+                                  <SortIcon src={downIcon} alt="sort-desc" />
+                                </SortIconWrapper>
+                              ),
+                            }[header.column.getIsSorted() as string] ?? null}
+                          </span>
+                        </>
                       )}
-                      <span>
-                        {{
-                          asc: (
-                            <SortIconWrapper>
-                              <SortIcon src={upIcon} alt="sort-asc" />
-                            </SortIconWrapper>
-                          ),
-                          desc: (
-                            <SortIconWrapper>
-                              <SortIcon src={downIcon} alt="sort-desc" />
-                            </SortIconWrapper>
-                          ),
-                        }[header.column.getIsSorted() as string] ?? null}
-                      </span>
-                    </>
-                  )}
-                </Th>
-              ))}
-            </TableHeader>
-          ))}
+                    </Th>
+                  );
+                })}
+              </TableHeader>
+            );
+          })}
         </TableHead>
         {tableBodyLoading ? (
           <TableBodyLoadingWrapper

--- a/app/src/components/tables/Pagination/NumberedPagination.tsx
+++ b/app/src/components/tables/Pagination/NumberedPagination.tsx
@@ -256,7 +256,7 @@ const SelectWrapper = styled.div<{ isMenuOpen: boolean }>`
 
   .react-select__menu-list {
     color: ${colors.black};
-    font-size: clamp(1rem, 1.2vw, 1.4rem);
+    font-size: 1rem;
     padding: 0;
     margin: 0;
     border-radius: 0.375rem;

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -18,11 +18,12 @@ import {
   useAppDispatch,
   useAppSelector,
 } from 'src/store';
-import { truncateHash } from 'src/utils';
+import { standardizeNumber, truncateHash } from 'src/utils';
 import { ApiData } from 'src/api/types';
 import { Link } from 'react-router-dom';
 import { CopyToClipboard } from 'src/components/utility';
 import { SelectOptions } from 'src/components/layout/Header/Partials';
+import { DEFAULT_SECONDARY_FONT_FAMILIES } from 'src/constants';
 import { Table } from '../../base';
 import { NumberedPagination } from '../Pagination';
 
@@ -117,28 +118,44 @@ export const ValidatorTable: React.FC = () => {
       {
         header: `${t('fee-percentage')}`,
         accessorKey: 'feePercentage',
-        // cell: () => (
-
-        // )
+        cell: ({ getValue }) =>
+          `${getValue<number>().toLocaleString('en', {
+            useGrouping: false,
+            minimumFractionDigits: 2,
+          })}%`,
       },
       {
         header: `${t('delegators')}`,
         accessorKey: 'delegatorsCount',
-        enableSorting: false,
+        cell: ({ getValue }) => standardizeNumber(getValue<number>()),
       },
       {
         header: `${t('total-stake')}`,
         accessorKey: 'totalStakeMotes',
+        cell: ({ getValue }) => (
+          <CSPRText>
+            {/* TODO: use BigNumber.js library here? */}
+            {standardizeNumber((getValue<number>() / 10 ** 9).toFixed(0))} CSPR
+          </CSPRText>
+        ),
       },
       {
         header: `${t('self-percentage')}`,
         accessorKey: 'selfPercentage',
-        enableSorting: false,
+        cell: ({ getValue }) =>
+          `${getValue<number>().toLocaleString('en', {
+            useGrouping: false,
+            minimumFractionDigits: 2,
+          })}%`,
       },
       {
         header: `${t('network-percentage')}`,
         accessorKey: 'percentageOfNetwork',
-        enableSorting: false,
+        cell: ({ getValue }) =>
+          `${getValue<number>().toLocaleString('en', {
+            useGrouping: false,
+            minimumFractionDigits: 2,
+          })}%`,
       },
     ],
     [t],
@@ -212,4 +229,8 @@ const ValidatorFooter = styled.div`
 
 const HeadValue = styled.p`
   color: ${colors.darkSupporting};
+`;
+
+const CSPRText = styled.span`
+  font-family: ${DEFAULT_SECONDARY_FONT_FAMILIES};
 `;

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -132,7 +132,8 @@ export const ValidatorTable: React.FC = () => {
         cell: ({ getValue }) => (
           <CSPRText>
             {/* TODO: use BigNumber.js library here? */}
-            {standardizeNumber((getValue<number>() / 10 ** 9).toFixed(0))} CSPR
+            {standardizeNumber((getValue<number>() / 10 ** 9).toFixed(0))}{' '}
+            {t('cspr')}
           </CSPRText>
         ),
       },
@@ -168,6 +169,7 @@ export const ValidatorTable: React.FC = () => {
 
   const onSortingChange: OnChangeFn<SortingState> = updaterOrValue => {
     setIsTableLoading(true);
+
     if (updaterOrValue instanceof Function) {
       const [updatedVal] = updaterOrValue([
         {
@@ -176,6 +178,7 @@ export const ValidatorTable: React.FC = () => {
         },
       ]);
 
+      // TODO: if going from one id to the next -> shouldn't flip the asc/desc (default desc?)
       dispatch(
         updateValidatorSorting({
           sortBy: updatedVal.id,

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -12,6 +12,7 @@ import {
   getValidators,
   getValidatorsTableOptions,
   Loading,
+  resetValidatorTableOptions,
   setValidatorTableOptions,
   updateValidatorPageNum,
   updateValidatorSorting,
@@ -45,6 +46,10 @@ export const ValidatorTable: React.FC = () => {
 
   useEffect(() => {
     dispatch(fetchCurrentEraValidatorStatus());
+
+    return () => {
+      dispatch(resetValidatorTableOptions());
+    };
   }, [dispatch]);
 
   useEffect(() => {
@@ -99,11 +104,13 @@ export const ValidatorTable: React.FC = () => {
         header: `${t('rank')}`,
         accessorKey: 'rank',
         enableSorting: false,
+        maxSize: 100,
       },
       {
         header: `${t('public-key')}`,
         accessorKey: 'publicKey',
         enableSorting: false,
+        minSize: 200,
         cell: ({ getValue }) => (
           <div>
             <Link
@@ -119,16 +126,19 @@ export const ValidatorTable: React.FC = () => {
       {
         header: `${t('fee-percentage')}`,
         accessorKey: 'feePercentage',
+        maxSize: 125,
         cell: ({ getValue }) => standardizePercentage(getValue<number>(), 2),
       },
       {
         header: `${t('delegators')}`,
         accessorKey: 'delegatorsCount',
+        maxSize: 125,
         cell: ({ getValue }) => standardizeNumber(getValue<number>()),
       },
       {
         header: `${t('total-stake')}`,
         accessorKey: 'totalStakeMotes',
+        minSize: 200,
         cell: ({ getValue }) => (
           <CSPRText>
             {/* TODO: use BigNumber.js library here? */}
@@ -140,11 +150,13 @@ export const ValidatorTable: React.FC = () => {
       {
         header: `${t('self-percentage')}`,
         accessorKey: 'selfPercentage',
+        maxSize: 150,
         cell: ({ getValue }) => standardizePercentage(getValue<number>(), 2),
       },
       {
         header: `${t('network-percentage')}`,
         accessorKey: 'percentageOfNetwork',
+        maxSize: 150,
         cell: ({ getValue }) => standardizePercentage(getValue<number>(), 2),
       },
     ],

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -141,7 +141,7 @@ export const ValidatorTable: React.FC = () => {
         minSize: 200,
         cell: ({ getValue }) => (
           <CSPRText>
-            {/* TODO: use BigNumber.js library here? */}
+            {/* TODO: see https://github.com/casper-network/casper-blockexplorer-middleware/issues/23 */}
             {standardizeNumber((getValue<number>() / 10 ** 9).toFixed(0))}{' '}
             {t('cspr')}
           </CSPRText>

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -24,6 +24,7 @@ import { Link } from 'react-router-dom';
 import { CopyToClipboard } from 'src/components/utility';
 import { SelectOptions } from 'src/components/layout/Header/Partials';
 import { DEFAULT_SECONDARY_FONT_FAMILIES } from 'src/constants';
+import { standardizePercentage } from 'src/utils/standardize-percentage';
 import { Table } from '../../base';
 import { NumberedPagination } from '../Pagination';
 
@@ -118,11 +119,7 @@ export const ValidatorTable: React.FC = () => {
       {
         header: `${t('fee-percentage')}`,
         accessorKey: 'feePercentage',
-        cell: ({ getValue }) =>
-          `${getValue<number>().toLocaleString('en', {
-            useGrouping: false,
-            minimumFractionDigits: 2,
-          })}%`,
+        cell: ({ getValue }) => standardizePercentage(getValue<number>(), 2),
       },
       {
         header: `${t('delegators')}`,
@@ -142,20 +139,12 @@ export const ValidatorTable: React.FC = () => {
       {
         header: `${t('self-percentage')}`,
         accessorKey: 'selfPercentage',
-        cell: ({ getValue }) =>
-          `${getValue<number>().toLocaleString('en', {
-            useGrouping: false,
-            minimumFractionDigits: 2,
-          })}%`,
+        cell: ({ getValue }) => standardizePercentage(getValue<number>(), 2),
       },
       {
         header: `${t('network-percentage')}`,
         accessorKey: 'percentageOfNetwork',
-        cell: ({ getValue }) =>
-          `${getValue<number>().toLocaleString('en', {
-            useGrouping: false,
-            minimumFractionDigits: 2,
-          })}%`,
+        cell: ({ getValue }) => standardizePercentage(getValue<number>(), 2),
       },
     ],
     [t],

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -178,11 +178,15 @@ export const ValidatorTable: React.FC = () => {
         },
       ]);
 
-      // TODO: if going from one id to the next -> shouldn't flip the asc/desc (default desc?)
+      let order: 'desc' | 'asc' = 'desc';
+      if (validatorsTableOptions.sorting.sortBy === updatedVal.id) {
+        order = updatedVal.desc ? 'desc' : 'asc';
+      }
+
       dispatch(
         updateValidatorSorting({
           sortBy: updatedVal.id,
-          order: updatedVal.desc ? 'desc' : 'asc',
+          order,
         }),
       );
     }

--- a/app/src/pages/Blocks.tsx
+++ b/app/src/pages/Blocks.tsx
@@ -16,6 +16,7 @@ import {
   getTotalBlocks,
   getBlocksTableOptions,
   updateBlocksSorting,
+  restetBlocksTableOptions,
 } from 'src/store';
 import { SortingState } from '@tanstack/react-table';
 
@@ -66,6 +67,12 @@ export const Blocks: React.FC = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [blocks]);
+
+  useEffect(() => {
+    return () => {
+      dispatch(restetBlocksTableOptions());
+    };
+  }, [dispatch]);
 
   return (
     <PageWrapper isLoading={false}>

--- a/app/src/pages/Validators.tsx
+++ b/app/src/pages/Validators.tsx
@@ -16,11 +16,7 @@ export const Validators: React.FC = () => {
     <PageWrapper isLoading={false}>
       <PageHead pageTitle={pageTitle} />
       <GradientHeading type="h2">{t('active-validators')}</GradientHeading>
-      <ValidatorTable
-      // validators={validators}
-      // isTableLoading={isTableLoading || isPageLoading}
-      // setIsTableLoading={setIsTableLoading}
-      />
+      <ValidatorTable />
     </PageWrapper>
   );
 };

--- a/app/src/pages/Validators.tsx
+++ b/app/src/pages/Validators.tsx
@@ -1,16 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  fetchCurrentEraValidatorStatus,
-  fetchValidators,
-  getCurrentEraValidatorStatusStatus,
-  getValidatorLoadingStatus,
-  getValidators,
-  getValidatorsTableOptions,
-  Loading,
-  useAppDispatch,
-  useAppSelector,
-} from 'src/store';
 import {
   GradientHeading,
   PageHead,
@@ -19,38 +8,7 @@ import {
 } from '../components';
 
 export const Validators: React.FC = () => {
-  const [isTableLoading, setIsTableLoading] = useState(false);
-
   const { t } = useTranslation();
-
-  const dispatch = useAppDispatch();
-
-  const validators = useAppSelector(getValidators);
-  const validatorsTableOptions = useAppSelector(getValidatorsTableOptions);
-  const validatorsLoadingStatus = useAppSelector(getValidatorLoadingStatus);
-  const validatorsStatusLoadingStatus = useAppSelector(
-    getCurrentEraValidatorStatusStatus,
-  );
-
-  useEffect(() => {
-    dispatch(fetchCurrentEraValidatorStatus());
-  }, [dispatch]);
-
-  useEffect(() => {
-    dispatch(fetchValidators(validatorsTableOptions));
-  }, [dispatch, validatorsTableOptions]);
-
-  useEffect(() => {
-    if (isTableLoading) {
-      setIsTableLoading(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [validators]);
-
-  const isPageLoading =
-    validatorsLoadingStatus !== Loading.Complete ||
-    validatorsStatusLoadingStatus !== Loading.Complete ||
-    !validators.length;
 
   const pageTitle = `${t('validators')}`;
 
@@ -59,9 +17,9 @@ export const Validators: React.FC = () => {
       <PageHead pageTitle={pageTitle} />
       <GradientHeading type="h2">{t('active-validators')}</GradientHeading>
       <ValidatorTable
-        validators={validators}
-        isTableLoading={isTableLoading || isPageLoading}
-        setIsTableLoading={setIsTableLoading}
+      // validators={validators}
+      // isTableLoading={isTableLoading || isPageLoading}
+      // setIsTableLoading={setIsTableLoading}
       />
     </PageWrapper>
   );

--- a/app/src/store/slices/block-slice.ts
+++ b/app/src/store/slices/block-slice.ts
@@ -20,6 +20,17 @@ export interface BlockState {
   tableOptions: TableOptions;
 }
 
+const defaultTableOptions: TableOptions = {
+  pagination: {
+    pageSize: defaultPagination,
+    pageNum: 1,
+  },
+  sorting: {
+    sortBy: 'height',
+    order: 'desc',
+  },
+};
+
 const initialState: BlockState = {
   status: Loading.Idle,
   blocks: [],
@@ -29,16 +40,7 @@ const initialState: BlockState = {
   latestBlock: null,
   latestBlockLoadingStatus: Loading.Idle,
   totalBlocks: 0,
-  tableOptions: {
-    pagination: {
-      pageSize: defaultPagination,
-      pageNum: 1,
-    },
-    sorting: {
-      sortBy: 'height',
-      order: 'desc',
-    },
-  },
+  tableOptions: defaultTableOptions,
 };
 
 export const fetchBlocks = createAsyncThunk(
@@ -128,6 +130,9 @@ export const blockSlice = createSlice({
     ) => {
       state.tableOptions.sorting = action.payload;
     },
+    restetBlocksTableOptions: state => {
+      state.tableOptions = defaultTableOptions;
+    },
   },
   extraReducers(builder) {
     builder
@@ -178,4 +183,5 @@ export const {
   setBlocksTableOptions,
   updateBlocksPageNum,
   updateBlocksSorting,
+  restetBlocksTableOptions,
 } = blockSlice.actions;

--- a/app/src/store/slices/validator-slice.ts
+++ b/app/src/store/slices/validator-slice.ts
@@ -15,21 +15,23 @@ export interface ValidatorState {
   tableOptions: TableOptions;
 }
 
+const defaultTableOptions: TableOptions = {
+  pagination: {
+    pageSize: defaultPagination,
+    pageNum: 1,
+  },
+  sorting: {
+    sortBy: 'totalStakeMotes',
+    order: 'desc',
+  },
+};
+
 const initialState: ValidatorState = {
   status: Loading.Idle,
   validators: [],
   currentEraValidatorStatus: null,
   currentEraValidatorStatusLoadingStatus: Loading.Idle,
-  tableOptions: {
-    pagination: {
-      pageSize: defaultPagination,
-      pageNum: 1,
-    },
-    sorting: {
-      sortBy: 'totalStakeMotes',
-      order: 'desc',
-    },
-  },
+  tableOptions: defaultTableOptions,
 };
 
 export const fetchValidators = createAsyncThunk(
@@ -86,6 +88,9 @@ export const validatorSlice = createSlice({
     ) => {
       state.tableOptions.sorting = action.payload;
     },
+    resetValidatorTableOptions: state => {
+      state.tableOptions = defaultTableOptions;
+    },
   },
   extraReducers(builder) {
     builder
@@ -125,4 +130,5 @@ export const {
   setValidatorTableOptions,
   updateValidatorPageNum,
   updateValidatorSorting,
+  resetValidatorTableOptions,
 } = validatorSlice.actions;

--- a/app/src/store/slices/validator-slice.ts
+++ b/app/src/store/slices/validator-slice.ts
@@ -26,7 +26,7 @@ const initialState: ValidatorState = {
       pageNum: 1,
     },
     sorting: {
-      sortBy: '',
+      sortBy: 'totalStakeMotes',
       order: 'desc',
     },
   },

--- a/app/src/utils/standardize-percentage.ts
+++ b/app/src/utils/standardize-percentage.ts
@@ -1,0 +1,5 @@
+export const standardizePercentage = (num: number, decimals?: number) =>
+  `${num.toLocaleString('en', {
+    useGrouping: false,
+    minimumFractionDigits: decimals ?? 2,
+  })}%`;


### PR DESCRIPTION
### 🔥 Summary
- Update validators table to include formatted columns and sorting

### 📹 Video
https://user-images.githubusercontent.com/124628688/221926151-61ed02d5-111b-4bf3-aaaa-89b376f41717.mov

### 😤 Problem / Goals
- Currently the table has minimal styles and no sorting

### 🤓 Solution
-

### 🗒️ Additional Notes
- We are still waiting on UI/UX for designs on what a "neutral" column (one that is sortable, but not sorted currently) should look like. For now, we are just using a blank background icon.
- See https://github.com/casper-network/casper-blockexplorer-middleware/pull/27 for corresponding middleware implementation. Will need to merge at the same time.
