### PR TITLE
Fix: prevent mobile nav layout from rendering quickly on page load

### DIFF
--- a/app/src/hooks/use-app-width.ts
+++ b/app/src/hooks/use-app-width.ts
@@ -4,7 +4,7 @@ import { getBounds, useAppSelector } from '../store';
 export const useAppWidth = () => {
   const bounds = useAppSelector(getBounds);
 
-  const windowWidth = bounds?.width || 0;
+  const windowWidth = bounds?.width || window.innerWidth || 0;
 
   const isMobile = windowWidth < MOBILE_BREAKPOINT;
   const isDropdownMenu = windowWidth > SELECT_BREAKPOINT;


### PR DESCRIPTION
### 🔥 Summary
https://github.com/casper-network/casper-blockexplorer-frontend/issues/232: assign windowWidth to `window.innerWidth` while `useMeasure` is still loading values.

### 📹 Video

### 😤 Problem / Goals
-

### 🤓 Solution
-

### 🗒️ Additional Notes
-
