### PR TITLE
chore: fix vscode settings for working dirs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "eslint.workingDirectories": ["middleware", "frontend", "test"],
+  "eslint.workingDirectories": ["app", "test"],
   "editor.codeActionsOnSave": {
     "source.fixAll": true
   }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -18980,9 +18980,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.77.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.77.0.tgz",
+      "integrity": "sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -33715,9 +33715,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.77.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.77.0.tgz",
+      "integrity": "sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",


### PR DESCRIPTION
### 🔥 Summary
VS Code was painting red all over when open at the root of the project.   This is due to an incorrect working directory config in vscode settings.  This PR fixes that.