### PR TITLE
feat-267: dark mode details screens

### DIFF
--- a/app/src/components/base/InfoCard/InfoCard.styled.ts
+++ b/app/src/components/base/InfoCard/InfoCard.styled.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { breakpoints, colors, pxToRem } from '../../../styled-theme';
+import { breakpoints, pxToRem } from '../../../styled-theme';
 
 export const InfoCardSection = styled.section`
   margin: 0;
@@ -17,9 +17,9 @@ export const InfoCardSection = styled.section`
 
 export const InfoCardContentWrapper = styled.div`
   width: 100%;
-  background: ${colors.white};
-  border: 3px solid #4589f6;
-  box-shadow: 0px 0.125rem 0.5rem ${colors.boxShadow};
+  background: ${props => props.theme.background.primary};
+  border: 3px solid ${props => props.theme.border};
+  box-shadow: 0px 0.125rem 0.5rem ${props => props.theme.boxShadow};
   border-radius: 0.35rem;
   padding: 2rem;
   overflow-x: auto;

--- a/app/src/components/buttons/HashButton.tsx
+++ b/app/src/components/buttons/HashButton.tsx
@@ -47,7 +47,7 @@ const StyledHashButton = styled(Button)<{
   heading: string | undefined;
 }>`
   display: ${({ isMobile }) => (isMobile ? 'none' : 'block')};
-  color: ${colors.darkSupporting};
+  color: ${props => props.theme.text.secondary};
   font-weight: 400;
   background-color: transparent;
   border-style: none;

--- a/app/src/components/cards/AccountDetailsCard/AccountDetailsCard.tsx
+++ b/app/src/components/cards/AccountDetailsCard/AccountDetailsCard.tsx
@@ -155,6 +155,7 @@ const AccountHeading = styled(Heading)`
   font-size: 1.25rem;
   font-weight: ${fontWeight.normal};
   margin-bottom: 2rem;
+  color: ${props => props.theme.text.primary};
 `;
 
 const AccountDetailsWrapper = styled.div`
@@ -192,6 +193,6 @@ const HashHeading = styled(Heading)<{
   overflow-wrap: break-word;
   word-break: break-word;
   font-size: ${pxToRem(60)};
-  color: #2230f0;
+  color: ${props => props.theme.text.hash};
   line-height: 65px;
 `;

--- a/app/src/components/cards/BlockDetailsCard/BlockDetailsCard.tsx
+++ b/app/src/components/cards/BlockDetailsCard/BlockDetailsCard.tsx
@@ -93,17 +93,16 @@ export const BlockDetailsCard: React.FC<BlockDetailsCardProps> = ({
           <li>
             <DetailDataLabel>{t('parent-hash')}</DetailDataLabel>
             <DetailDataValue height="2rem">
-              <Link
+              <StyledHashLink
                 to={{
                   pathname: `/block/${block?.header.parent_hash ?? ''}`,
-                }}
-                style={{ color: '#2230f0' }}>
+                }}>
                 {withSkeletonLoading(
                   <Hash hash={block?.header.parent_hash ?? hashPlaceholder} />,
                   isLoading,
                   { width: 850 },
                 )}
-              </Link>
+              </StyledHashLink>
               {!isLoading && (
                 <CopyToClipboard textToCopy={block?.header.parent_hash ?? ''} />
               )}
@@ -135,17 +134,16 @@ export const BlockDetailsCard: React.FC<BlockDetailsCardProps> = ({
           <li>
             <DetailDataLabel>{t('validator')}</DetailDataLabel>
             <DetailDataValue height="2rem">
-              <Link
+              <StyledHashLink
                 to={{
                   pathname: `/account/${block?.body.proposer ?? ''}`,
-                }}
-                style={{ color: '#2230f0' }}>
+                }}>
                 {withSkeletonLoading(
                   <Hash hash={block?.body.proposer ?? hashPlaceholder} />,
                   isLoading,
                   { width: 850 },
                 )}
-              </Link>
+              </StyledHashLink>
               {!isLoading && (
                 <CopyToClipboard textToCopy={block?.body.proposer ?? ''} />
               )}
@@ -170,14 +168,12 @@ export const BlockDetailsCard: React.FC<BlockDetailsCardProps> = ({
                   <ul>
                     {block?.body.deploy_hashes?.map(deployHash => (
                       <li key={deployHash}>
-                        <a
-                          href={`/deploy/${deployHash}`}
-                          style={{ color: '#2230f0' }}>
+                        <StyledAnchorTag href={`/deploy/${deployHash}`}>
                           <Hash
                             alwaysTruncate
                             hash={deployHash ?? hashPlaceholder}
                           />
-                        </a>
+                        </StyledAnchorTag>
                       </li>
                     ))}
                   </ul>
@@ -197,14 +193,12 @@ export const BlockDetailsCard: React.FC<BlockDetailsCardProps> = ({
                   <ul>
                     {block?.body.transfer_hashes?.map(transferHash => (
                       <li key={transferHash}>
-                        <a
-                          href={`/deploy/${transferHash}`}
-                          style={{ color: '#2230f0' }}>
+                        <StyledAnchorTag href={`/deploy/${transferHash}`}>
                           <Hash
                             alwaysTruncate
                             hash={transferHash ?? hashPlaceholder}
                           />
-                        </a>
+                        </StyledAnchorTag>
                       </li>
                     ))}
                   </ul>
@@ -235,7 +229,7 @@ const HashHeading = styled(Heading)<{ isTruncated: boolean }>`
   min-width: ${pxToRem(360)};
   overflow-wrap: break-word;
   font-size: ${pxToRem(60)};
-  color: #2230f0;
+  color: ${props => props.theme.text.hash};
 `;
 
 const DetailDataRowWrapper = styled.ul`
@@ -252,4 +246,12 @@ const PageHeading = styled.div`
   @media only screen and (min-width: ${breakpoints.lg}) {
     margin-bottom: 2rem;
   }
+`;
+
+const StyledHashLink = styled(Link)`
+  color: ${props => props.theme.text.hash};
+`;
+
+const StyledAnchorTag = styled.a`
+  color: ${props => props.theme.text.hash};
 `;

--- a/app/src/components/cards/DeployDetailsCard/DeployDetailsCard.tsx
+++ b/app/src/components/cards/DeployDetailsCard/DeployDetailsCard.tsx
@@ -65,11 +65,9 @@ export const DeployDetailsCard: React.FC<DeployDetailsCardProps> = ({
               <DetailDataValue height="2rem">
                 {withSkeletonLoading(
                   <>
-                    <Link
-                      to={`/block/${deploy?.blockHash ?? ''}`}
-                      style={{ color: '#2230f0' }}>
+                    <StyledHashLink to={`/block/${deploy?.blockHash ?? ''}`}>
                       <Hash hash={deploy?.blockHash ?? hashPlaceholder} />
-                    </Link>
+                    </StyledHashLink>
                     <CopyToClipboard textToCopy={deploy?.blockHash ?? ''} />
                   </>,
                   isLoading,
@@ -82,11 +80,9 @@ export const DeployDetailsCard: React.FC<DeployDetailsCardProps> = ({
               <DetailDataValue height="2rem">
                 {withSkeletonLoading(
                   <>
-                    <Link
-                      to={`/account/${deploy?.publicKey ?? ''}`}
-                      style={{ color: '#2230f0' }}>
+                    <StyledHashLink to={`/account/${deploy?.publicKey ?? ''}`}>
                       <Hash hash={deploy?.publicKey ?? hashPlaceholder} />
-                    </Link>
+                    </StyledHashLink>
                     <CopyToClipboard textToCopy={deploy?.publicKey ?? ''} />
                   </>,
                   isLoading,
@@ -143,5 +139,9 @@ const HashHeading = styled(Heading)<{
   width: ${({ isTruncated }) => (isTruncated ? '40%' : '75vw')};
   overflow-wrap: ${({ isMobile }) => (isMobile ? 'none' : 'break-word')};
   font-size: ${pxToRem(60)};
-  color: #2230f0;
+  color: ${props => props.theme.text.hash};
+`;
+
+const StyledHashLink = styled(Link)`
+  color: ${props => props.theme.text.hash};
 `;

--- a/app/src/components/cards/TransactionDetailsCard/TransactionDetailsCard.tsx
+++ b/app/src/components/cards/TransactionDetailsCard/TransactionDetailsCard.tsx
@@ -144,10 +144,12 @@ const TransactionGrid = styled(Grid)`
 const TransactionHeading = styled(Heading)`
   font-size: ${pxToRem(18)};
   font-weight: ${fontWeight.medium};
+  color: ${props => props.theme.text.primary};
 `;
 
 const TransactionDetailData = styled.div`
   font-size: ${pxToRem(26)};
+  color: ${props => props.theme.text.primary};
 `;
 
 const DeployStatusData = styled(TransactionDetailData)`

--- a/app/src/components/styled/DetailData/DetailData.styled.ts
+++ b/app/src/components/styled/DetailData/DetailData.styled.ts
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
-import { colors, fontWeight, pxToRem } from '../../../styled-theme';
+import { fontWeight, pxToRem } from '../../../styled-theme';
 
 export const DetailDataLabel = styled.h3`
   font-weight: ${fontWeight.normal};
   font-size: 1.25rem;
-  color: #7a7a7a;
+  color: ${props => props.theme.text.secondary};
 `;
 
 export const DetailDataWrapper = styled.ul`
@@ -32,6 +32,6 @@ export const DetailDataValue = styled.div<{
   height: ${({ height }) =>
     typeof height === 'number' ? `${height}px` : height};
   font-size: ${({ isLargeText }) => (isLargeText ? pxToRem(40) : '1.25rem')};
-  color: ${colors.black};
+  color: ${props => props.theme.text.primary};
   font-weight: ${fontWeight.normal};
 `;

--- a/app/src/components/utility/RawData/RawData.tsx
+++ b/app/src/components/utility/RawData/RawData.tsx
@@ -10,7 +10,7 @@ import {
   AccordionItemState,
 } from 'react-accessible-accordion';
 import styled from '@emotion/styled';
-import { colors, fontWeight, pxToRem } from '../../../styled-theme';
+import { fontWeight, pxToRem } from '../../../styled-theme';
 
 interface RawDataProps {
   readonly rawData: string;
@@ -53,8 +53,8 @@ const RawDataToggleButton = styled(AccordionItemButton)`
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: ${colors.lightSupporting};
-  color: ${colors.black};
+  background-color: ${props => props.theme.background.secondary};
+  color: ${props => props.theme.text.primary};
   padding: 0.4rem 1.25rem;
   font-size: 1.25rem;
   font-weight: ${fontWeight.medium};
@@ -64,7 +64,8 @@ const RawDataToggleButton = styled(AccordionItemButton)`
   height: ${pxToRem(55)};
 
   &:hover {
-    background-color: ${colors.lightWarning};
+    background-color: ${props => props.theme.background.hover};
+    cursor: pointer;
   }
 `;
 
@@ -72,5 +73,9 @@ const CodeBackground = styled.div`
   padding: 1.5rem;
   border-radius: 0.5rem;
   margin-top: 1.5rem;
-  background-color: ${colors.lightSupporting};
+  background-color: ${props => props.theme.background.secondary};
+
+  * {
+    color: ${props => props.theme.text.primary};
+  }
 `;


### PR DESCRIPTION
### 🔥 Summary
https://github.com/casper-network/casper-blockexplorer-frontend/issues/267

### 📹 Video
<img width="1227" alt="Screenshot 2023-04-26 at 12 05 57 PM" src="https://user-images.githubusercontent.com/124628688/234664675-e65cc1ba-73a9-47ae-a51b-8bb61678926d.png">
<img width="1216" alt="Screenshot 2023-04-26 at 12 05 50 PM" src="https://user-images.githubusercontent.com/124628688/234664676-faf371ed-2190-4bbf-b3a7-76f68c96edf5.png">
<img width="1221" alt="Screenshot 2023-04-26 at 12 05 45 PM" src="https://user-images.githubusercontent.com/124628688/234664677-e2418ed1-4045-44f7-822c-d50c9ba254b0.png">
<img width="1226" alt="Screenshot 2023-04-26 at 12 05 30 PM" src="https://user-images.githubusercontent.com/124628688/234664682-2ee3907d-a7ef-4c4d-9473-d942a259c741.png">


### 😤 Problem / Goals
-

### 🤓 Solution
-

### 🗒️ Additional Notes
-
