### PR TITLE
feat-268: store theme value in local storage

### DIFF
--- a/app/src/components/layout/ThemeToggler/ThemeToggler.tsx
+++ b/app/src/components/layout/ThemeToggler/ThemeToggler.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { DarkModeIcon, LightModeIcon } from 'src/components/icons';
 import { pxToRem } from 'src/styled-theme';
 
@@ -11,20 +11,40 @@ interface ThemeTogglerProps {
 export const ThemeToggler: React.FC<ThemeTogglerProps> = ({
   isLightTheme,
   setIsLightTheme,
-}) => (
-  <ThemeTogglerWrapper>
-    <IconWrapper
-      isSelected={isLightTheme}
-      onClick={() => setIsLightTheme(true)}>
-      <LightModeIcon />
-    </IconWrapper>
-    <IconWrapper
-      isSelected={!isLightTheme}
-      onClick={() => setIsLightTheme(false)}>
-      <DarkModeIcon />
-    </IconWrapper>
-  </ThemeTogglerWrapper>
-);
+}) => {
+  useEffect(() => {
+    let isLightModeConfig = localStorage.getItem('isLightMode');
+
+    if (isLightModeConfig !== null) {
+      isLightModeConfig = JSON.parse(isLightModeConfig);
+
+      if (typeof isLightModeConfig === 'boolean') {
+        setIsLightTheme(isLightModeConfig);
+      }
+    }
+  }, []);
+
+  const setThemeToLocalStorage = (isLightTheme: boolean) => {
+    localStorage.setItem('isLightMode', JSON.stringify(isLightTheme));
+
+    setIsLightTheme(isLightTheme);
+  };
+
+  return (
+    <ThemeTogglerWrapper>
+      <IconWrapper
+        isSelected={isLightTheme}
+        onClick={() => setThemeToLocalStorage(true)}>
+        <LightModeIcon />
+      </IconWrapper>
+      <IconWrapper
+        isSelected={!isLightTheme}
+        onClick={() => setThemeToLocalStorage(false)}>
+        <DarkModeIcon />
+      </IconWrapper>
+    </ThemeTogglerWrapper>
+  );
+};
 
 const ThemeTogglerWrapper = styled.div`
   position: fixed;

--- a/app/src/components/layout/ThemeToggler/ThemeToggler.tsx
+++ b/app/src/components/layout/ThemeToggler/ThemeToggler.tsx
@@ -16,13 +16,13 @@ export const ThemeToggler: React.FC<ThemeTogglerProps> = ({
     let isLightModeConfig = localStorage.getItem('isLightMode');
 
     if (isLightModeConfig !== null) {
-      isLightModeConfig = JSON.parse(isLightModeConfig);
+      isLightModeConfig = JSON.parse(isLightModeConfig) as string;
 
       if (typeof isLightModeConfig === 'boolean') {
         setIsLightTheme(isLightModeConfig);
       }
     }
-  }, []);
+  }, [setIsLightTheme]);
 
   const setThemeToLocalStorage = (isLightTheme: boolean) => {
     localStorage.setItem('isLightMode', JSON.stringify(isLightTheme));


### PR DESCRIPTION
### 🔥 Summary
https://github.com/casper-network/casper-blockexplorer-frontend/issues/268

### 📹 Video

### 😤 Problem / Goals
- 

### 🤓 Solution
- Adding theme value to local storage in order to save on refresh for better UX.

### 🗒️ Additional Notes
-
