### PR TITLE
Fix: Update Casper UI Kit & Re-add PageWrapper/Navbar Test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ node_modules/
 /coverage
 
 # production
-/build
+build/
 
 # misc
 .DS_Store

--- a/app/.eslintignore
+++ b/app/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 config/
 scripts/
+build/

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -63,7 +63,7 @@
         "bfj": "^7.0.2",
         "browserslist": "^4.18.1",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
-        "casper-ui-kit": "^0.1.1",
+        "casper-ui-kit": "^0.5.2",
         "css-loader": "^6.5.1",
         "css-minimizer-webpack-plugin": "^3.2.0",
         "dotenv": "^10.0.0",
@@ -6688,9 +6688,9 @@
       }
     },
     "node_modules/casper-ui-kit": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/casper-ui-kit/-/casper-ui-kit-0.1.1.tgz",
-      "integrity": "sha512-rrEo+elAd7BoTvduaLl+m5s+VQR+g5cO6Gzb3eDBuL9F261V7UI6/8B46TCS6q+fMcL0cuBqe56fGBEzTZU+oA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/casper-ui-kit/-/casper-ui-kit-0.5.2.tgz",
+      "integrity": "sha512-V812OOke7hV/fQ20SLj6+ey+EaSv1sfm+s81Y8gNlgz6BFb4QPvH73LIQ9bFY6xvRnIV/Ubbq6fp8dUyaPu5zA==",
       "dev": true,
       "dependencies": {
         "@emotion/react": "^11.10.5",
@@ -25074,9 +25074,9 @@
       }
     },
     "casper-ui-kit": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/casper-ui-kit/-/casper-ui-kit-0.1.1.tgz",
-      "integrity": "sha512-rrEo+elAd7BoTvduaLl+m5s+VQR+g5cO6Gzb3eDBuL9F261V7UI6/8B46TCS6q+fMcL0cuBqe56fGBEzTZU+oA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/casper-ui-kit/-/casper-ui-kit-0.5.2.tgz",
+      "integrity": "sha512-V812OOke7hV/fQ20SLj6+ey+EaSv1sfm+s81Y8gNlgz6BFb4QPvH73LIQ9bFY6xvRnIV/Ubbq6fp8dUyaPu5zA==",
       "dev": true,
       "requires": {
         "@emotion/react": "^11.10.5",

--- a/app/package.json
+++ b/app/package.json
@@ -58,7 +58,7 @@
     "bfj": "^7.0.2",
     "browserslist": "^4.18.1",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
-    "casper-ui-kit": "^0.1.1",
+    "casper-ui-kit": "^0.5.2",
     "css-loader": "^6.5.1",
     "css-minimizer-webpack-plugin": "^3.2.0",
     "dotenv": "^10.0.0",

--- a/app/src/components/layout/Navbar/Navbar.test.tsx
+++ b/app/src/components/layout/Navbar/Navbar.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render } from '../../../test-utils';
+import { Navbar } from './Navbar';
+
+jest.mock('../../../hooks', () => {
+  return {
+    useAppWidth: () => {
+      return { windowWidth: 1022, isMobile: false };
+    },
+  };
+});
+
+jest.mock('react-i18next', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const englishTranslations = jest.requireActual(
+    '../../../../public/locales/en/translation.json',
+  );
+
+  return {
+    useTranslation: () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+      return { t: (key: string) => englishTranslations[key] };
+    },
+  };
+});
+
+describe('Navbar', () => {
+  it('should render the Navbar component and contain nav items', () => {
+    const { getByTestId } = render(<Navbar />);
+
+    const nav = getByTestId('navigation');
+
+    expect(nav).toBeInTheDocument();
+    expect(nav).toHaveTextContent('Home');
+    expect(nav).toHaveTextContent('Blocks');
+    expect(nav).toHaveTextContent('Peers');
+  });
+
+  it('should hide navigation text content when screen width is below 1023px', () => {
+    const { getByText } = render(<Navbar />);
+    const navItem1 = getByText('Home');
+    const navItem2 = getByText('Blocks');
+    const navItem3 = getByText('Peers');
+
+    expect(navItem1).not.toBeVisible();
+    expect(navItem2).not.toBeVisible();
+    expect(navItem3).not.toBeVisible();
+  });
+});

--- a/app/src/components/layout/PageWrapper/PageWrapper.test.tsx
+++ b/app/src/components/layout/PageWrapper/PageWrapper.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render } from '../../../test-utils';
+import { PageWrapper } from './PageWrapper';
+
+jest.mock('react-i18next', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const englishTranslations = jest.requireActual(
+    '../../../../public/locales/en/translation.json',
+  );
+
+  return {
+    useTranslation: () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+      return { t: (key: string) => englishTranslations[key] };
+    },
+  };
+});
+
+describe(PageWrapper, () => {
+  it('should render loader when page is loading', () => {
+    const { getByTestId } = render(
+      <PageWrapper isLoading>Content</PageWrapper>,
+    );
+
+    const loader = getByTestId('loader');
+
+    expect(loader).toBeInTheDocument();
+  });
+
+  it('should render error content when error occurred', () => {
+    const { getByTestId } = render(
+      <PageWrapper isLoading={false} error={{ message: 'error message' }}>
+        Content
+      </PageWrapper>,
+    );
+
+    const errorContent = getByTestId('error-content');
+
+    expect(errorContent).toBeInTheDocument();
+    expect(errorContent.textContent).toContain('error message');
+  });
+
+  it('should render children when done loading & no error', () => {
+    const { getByTestId } = render(
+      <PageWrapper isLoading={false}>
+        <p data-testid="children-content">Content</p>
+      </PageWrapper>,
+    );
+
+    const pageContent = getByTestId('children-content').textContent;
+
+    expect(pageContent).toBe('Content');
+  });
+});


### PR DESCRIPTION
### 🔥 Summary
We recently removed the `PageWrapper` test due to a bug within the Casper UI Kit.  A fix has been released so now we can add that test back.

### 😤 Problem / Goals
- `PageWrapper` test was failing due to a Casper UI Kit bug

### 🤓 Solution
- Bump version of the Casper UI Kit to 0.5.2
- Re add in `PageWrapper `test

### 🗒️ Additional Notes
- Also noticed we weren't git or eslint ignoring the build folder correctly
