### PR TITLE
fix: revert casper ui kit card swap

### DIFF
--- a/app/src/components/base/DetailCard/DetailCard.tsx
+++ b/app/src/components/base/DetailCard/DetailCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { Card } from 'casper-ui-kit';
-import { InfoCardSection } from '../InfoCard';
+import { InfoCard, FootContentWrapper, HeadContentWrapper } from '../InfoCard';
 import { TableLabel, TableValue } from './DetailCard.styled';
 import { DetailCardProps } from './DetailCard.types';
 
@@ -11,8 +10,8 @@ export const DetailCard: React.FC<DetailCardProps> = ({
   footContent,
 }) => {
   return (
-    <InfoCardSection>
-      {!!headContent && <Card.Header>{headContent}</Card.Header>}
+    <InfoCard>
+      {!!headContent && <HeadContentWrapper>{headContent}</HeadContentWrapper>}
       <InfoCardTable>
         <tbody>
           {rows.map(({ detailKey, value, key }, index) => {
@@ -25,8 +24,8 @@ export const DetailCard: React.FC<DetailCardProps> = ({
           })}
         </tbody>
       </InfoCardTable>
-      {!!footContent && <Card.Footer>{footContent}</Card.Footer>}
-    </InfoCardSection>
+      {!!footContent && <FootContentWrapper>{footContent}</FootContentWrapper>}
+    </InfoCard>
   );
 };
 

--- a/app/src/components/base/InfoCard/InfoCard.styled.ts
+++ b/app/src/components/base/InfoCard/InfoCard.styled.ts
@@ -1,22 +1,19 @@
 import styled from '@emotion/styled';
-import { Card } from 'casper-ui-kit';
 import { breakpoints, pxToRem } from '../../../styled-theme';
 
-export const InfoCardSection = styled(Card)`
+export const InfoCardSection = styled.section`
   margin: 0;
   padding: 0;
   width: 100%;
-
   @media (min-width: ${breakpoints.md}) {
     padding-top: ${pxToRem(24)};
   }
-
   @media only screen and (min-width: ${breakpoints.lg}) {
     padding-top: ${pxToRem(15)};
   }
 `;
 
-export const InfoCardContentWrapper = styled(Card)`
+export const InfoCardContentWrapper = styled.div`
   width: 100%;
   background: ${props => props.theme.background.primary};
   border: 3px solid ${props => props.theme.border};
@@ -25,16 +22,13 @@ export const InfoCardContentWrapper = styled(Card)`
   padding: 2rem;
   overflow-x: auto;
   margin-bottom: 2rem;
-
   @media only screen and (min-width: ${breakpoints.md}) {
     max-width: 100vw;
   }
 `;
-
 export const HeadContentWrapper = styled.div`
   margin-bottom: 2rem;
 `;
-
 export const FootContentWrapper = styled.div`
   margin-top: 1rem;
 `;

--- a/app/src/components/base/InfoCard/index.ts
+++ b/app/src/components/base/InfoCard/index.ts
@@ -1,1 +1,2 @@
 export * from './InfoCard.styled';
+export * from './InfoCard';

--- a/app/src/components/cards/AccountDetailsCard/AccountDetailsCard.tsx
+++ b/app/src/components/cards/AccountDetailsCard/AccountDetailsCard.tsx
@@ -10,15 +10,10 @@ import {
   Loading,
   useAppSelector,
 } from 'src/store';
-import { Card } from 'casper-ui-kit';
 import { AVATAR_URL } from '../../../constants';
 
 import { Account } from '../../../api';
-import {
-  HeadContentWrapper,
-  Heading,
-  InfoCardContentWrapper,
-} from '../../base';
+import { HeadContentWrapper, Heading, InfoCard } from '../../base';
 import {
   Hash,
   AvatarIcon,
@@ -27,7 +22,6 @@ import {
   DetailDataValue,
   DetailDataList,
 } from '../../styled';
-
 import {
   Coin,
   CopyToClipboard,
@@ -40,7 +34,6 @@ export interface AccountDetailsCardProps {
   account: Account | null;
   balance: string | null;
 }
-
 export const AccountDetailsCard: React.FC<AccountDetailsCardProps> = ({
   account,
   balance,
@@ -48,13 +41,10 @@ export const AccountDetailsCard: React.FC<AccountDetailsCardProps> = ({
   const [isTruncated, setIsTruncated] = useState<boolean>(true);
   const { isMobile } = useAppWidth();
   const { t } = useTranslation();
-
   const accountLoadingStatus = useAppSelector(getAccountLoadingStatus);
   const balanceLoadingStatus = useAppSelector(getBalanceLoadingStatus);
-
   const isAccountLoading = accountLoadingStatus !== Loading.Complete;
   const isBalanceLoading = balanceLoadingStatus !== Loading.Complete;
-
   return (
     <>
       <HeadContentContainer isTruncated={isTruncated}>
@@ -89,104 +79,96 @@ export const AccountDetailsCard: React.FC<AccountDetailsCardProps> = ({
         </AvatarHashContainer>
       </HeadContentContainer>
 
-      <InfoCardContentWrapper>
-        <Card.Body>
-          <DetailDataWrapper>
-            <DetailDataList gap="1.75rem">
-              <li>
-                <DetailDataLabel>{t('account-hash')}</DetailDataLabel>
-                <DetailDataValue height="2rem">
-                  {withSkeletonLoading(
+      <InfoCard>
+        <DetailDataWrapper>
+          <DetailDataList gap="1.75rem">
+            <li>
+              <DetailDataLabel>{t('account-hash')}</DetailDataLabel>
+              <DetailDataValue height="2rem">
+                {withSkeletonLoading(
+                  <>
+                    <Hash
+                      hash={account?.trimmedAccountHash ?? hashPlaceholder}
+                    />
+                    <CopyToClipboard
+                      textToCopy={account?.trimmedAccountHash ?? ''}
+                    />
+                  </>,
+                  isAccountLoading,
+                  { width: '60%' },
+                )}
+              </DetailDataValue>
+            </li>
+            <li>
+              <DetailDataLabel>{t('public-key')}</DetailDataLabel>
+              <DetailDataValue>
+                {withSkeletonLoading(
+                  account?.publicKey ? (
                     <>
-                      <Hash
-                        hash={account?.trimmedAccountHash ?? hashPlaceholder}
-                      />
-                      <CopyToClipboard
-                        textToCopy={account?.trimmedAccountHash ?? ''}
-                      />
-                    </>,
-                    isAccountLoading,
-                    { width: '60%' },
-                  )}
-                </DetailDataValue>
-              </li>
-              <li>
-                <DetailDataLabel>{t('public-key')}</DetailDataLabel>
-                <DetailDataValue>
-                  {withSkeletonLoading(
-                    account?.publicKey ? (
-                      <>
-                        <Hash hash={account?.publicKey} />
-                        <CopyToClipboard textToCopy={account?.publicKey} />
-                      </>
-                    ) : (
-                      'Unknown'
-                    ),
-                    isAccountLoading,
-                    { width: '60%' },
-                  )}
-                </DetailDataValue>
-              </li>
+                      <Hash hash={account?.publicKey} />
+                      <CopyToClipboard textToCopy={account?.publicKey} />
+                    </>
+                  ) : (
+                    'Unknown'
+                  ),
+                  isAccountLoading,
+                  { width: '60%' },
+                )}
+              </DetailDataValue>
+            </li>
 
-              <li>
-                <DetailDataLabel>{t('balance')}</DetailDataLabel>
-                <DetailDataValue>
-                  {withSkeletonLoading(
-                    <Coin>{balance ?? ''}</Coin>,
-                    isBalanceLoading || balance === null,
-                    { width: 250 },
-                  )}
-                </DetailDataValue>
-              </li>
-              <li>
-                <DetailDataLabel>{t('raw-data')}</DetailDataLabel>
-                <DetailDataValue>
-                  {withSkeletonLoading(
-                    account?.rawAccount && (
-                      <RawData rawData={account?.rawAccount} />
-                    ),
-                    isAccountLoading,
-                    { width: 200, height: '2.25rem' },
-                  )}
-                </DetailDataValue>
-              </li>
-            </DetailDataList>
-          </DetailDataWrapper>
-        </Card.Body>
-      </InfoCardContentWrapper>
+            <li>
+              <DetailDataLabel>{t('balance')}</DetailDataLabel>
+              <DetailDataValue>
+                {withSkeletonLoading(
+                  <Coin>{balance ?? ''}</Coin>,
+                  isBalanceLoading || balance === null,
+                  { width: 250 },
+                )}
+              </DetailDataValue>
+            </li>
+            <li>
+              <DetailDataLabel>{t('raw-data')}</DetailDataLabel>
+              <DetailDataValue>
+                {withSkeletonLoading(
+                  account?.rawAccount && (
+                    <RawData rawData={account?.rawAccount} />
+                  ),
+                  isAccountLoading,
+                  { width: 200, height: '2.25rem' },
+                )}
+              </DetailDataValue>
+            </li>
+          </DetailDataList>
+        </DetailDataWrapper>
+      </InfoCard>
     </>
   );
 };
-
 const AccountHeading = styled(Heading)`
   font-size: 1.25rem;
   font-weight: ${fontWeight.normal};
   margin-bottom: 2rem;
   color: ${props => props.theme.text.primary};
 `;
-
 const AccountDetailsWrapper = styled.div`
   display: flex;
 `;
-
 const HeadContentContainer = styled(HeadContentWrapper)<{
   isTruncated?: boolean;
 }>`
   margin: 0;
   margin-bottom: ${({ isTruncated }) => (isTruncated ? '0.5rem' : '5rem')};
 `;
-
 const AvatarHashContainer = styled.div`
   display: flex;
   align-items: flex-start;
   height: ${pxToRem(130)};
 `;
-
 const HashExpandWrapper = styled.div`
   overflow-wrap: break-word;
   height: ${pxToRem(92)};
 `;
-
 const HashHeading = styled(Heading)<{
   isTruncated: boolean;
   isMobile: boolean;

--- a/app/src/components/cards/BlockDetailsCard/BlockDetailsCard.tsx
+++ b/app/src/components/cards/BlockDetailsCard/BlockDetailsCard.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -6,8 +7,7 @@ import { ApiData } from 'src/api/types';
 import { HashButton } from 'src/components/buttons';
 import { breakpoints, fontWeight, pxToRem } from 'src/styled-theme';
 import { hashPlaceholder } from 'src/utils';
-import { Card } from 'casper-ui-kit';
-import { Heading, InfoCardContentWrapper, Spacer } from '../../base';
+import { Heading, InfoCard, Spacer } from '../../base';
 import {
   DetailDataLabel,
   DetailDataValue,
@@ -20,16 +20,13 @@ export interface BlockDetailsCardProps {
   block: ApiData.Block | null;
   isLoading: boolean;
 }
-
 export const BlockDetailsCard: React.FC<BlockDetailsCardProps> = ({
   block,
   isLoading,
 }) => {
   const [isTruncated, setIsTruncated] = useState(true);
   const { t } = useTranslation();
-
   const rawBlock = JSON.stringify(block);
-
   return (
     <>
       <PageHeading>
@@ -55,182 +52,172 @@ export const BlockDetailsCard: React.FC<BlockDetailsCardProps> = ({
         </HashWrapper>
       </PageHeading>
 
-      <InfoCardContentWrapper>
-        <Card.Body>
-          <DetailDataRowWrapper>
-            <li>
-              <DetailDataLabel>{t('block-height')}</DetailDataLabel>
-              <DetailDataValue isLargeText>
-                {withSkeletonLoading(block?.header.height, isLoading, {
-                  width: 100,
-                })}
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('current-era')}</DetailDataLabel>
-              <DetailDataValue isLargeText>
-                {withSkeletonLoading(block?.header.era_id, isLoading, {
-                  width: 100,
-                })}
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('timestamp')}</DetailDataLabel>
-              <DetailDataValue isLargeText>
-                {withSkeletonLoading(
-                  block?.header.timestamp.toLocaleString(),
-                  isLoading,
-                  {
-                    width: 275,
-                  },
-                )}
-              </DetailDataValue>
-            </li>
-          </DetailDataRowWrapper>
+      <InfoCard>
+        <DetailDataRowWrapper>
+          <li>
+            <DetailDataLabel>{t('block-height')}</DetailDataLabel>
+            <DetailDataValue isLargeText>
+              {withSkeletonLoading(block?.header.height, isLoading, {
+                width: 100,
+              })}
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('current-era')}</DetailDataLabel>
+            <DetailDataValue isLargeText>
+              {withSkeletonLoading(block?.header.era_id, isLoading, {
+                width: 100,
+              })}
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('timestamp')}</DetailDataLabel>
+            <DetailDataValue isLargeText>
+              {withSkeletonLoading(
+                block?.header.timestamp.toLocaleString(),
+                isLoading,
+                {
+                  width: 275,
+                },
+              )}
+            </DetailDataValue>
+          </li>
+        </DetailDataRowWrapper>
 
-          <Spacer height="2.5rem" />
+        <Spacer height="2.5rem" />
 
-          <DetailDataWrapper>
-            <li>
-              <DetailDataLabel>{t('parent-hash')}</DetailDataLabel>
-              <DetailDataValue height="2rem">
-                <StyledHashLink
-                  to={{
-                    pathname: `/block/${block?.header.parent_hash ?? ''}`,
-                  }}>
-                  {withSkeletonLoading(
-                    <Hash
-                      hash={block?.header.parent_hash ?? hashPlaceholder}
-                    />,
-                    isLoading,
-                    { width: 850 },
-                  )}
-                </StyledHashLink>
-                {!isLoading && (
-                  <CopyToClipboard
-                    textToCopy={block?.header.parent_hash ?? ''}
-                  />
-                )}
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('block-hash')}</DetailDataLabel>
-              <DetailDataValue height="2rem">
+        <DetailDataWrapper>
+          <li>
+            <DetailDataLabel>{t('parent-hash')}</DetailDataLabel>
+            <DetailDataValue height="2rem">
+              <StyledHashLink
+                to={{
+                  pathname: `/block/${block?.header.parent_hash ?? ''}`,
+                }}>
                 {withSkeletonLoading(
-                  <Hash hash={block?.hash ?? hashPlaceholder} />,
+                  <Hash hash={block?.header.parent_hash ?? hashPlaceholder} />,
                   isLoading,
                   { width: 850 },
                 )}
-                {!isLoading && (
-                  <CopyToClipboard textToCopy={block?.hash ?? ''} />
-                )}
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('state-root-hash')}</DetailDataLabel>
-              <DetailDataValue>
+              </StyledHashLink>
+              {!isLoading && (
+                <CopyToClipboard textToCopy={block?.header.parent_hash ?? ''} />
+              )}
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('block-hash')}</DetailDataLabel>
+            <DetailDataValue height="2rem">
+              {withSkeletonLoading(
+                <Hash hash={block?.hash ?? hashPlaceholder} />,
+                isLoading,
+                { width: 850 },
+              )}
+              {!isLoading && <CopyToClipboard textToCopy={block?.hash ?? ''} />}
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('state-root-hash')}</DetailDataLabel>
+            <DetailDataValue>
+              {withSkeletonLoading(
+                <Hash
+                  hash={block?.header.state_root_hash ?? hashPlaceholder}
+                />,
+                isLoading,
+                { width: 850 },
+              )}
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('validator')}</DetailDataLabel>
+            <DetailDataValue height="2rem">
+              <StyledHashLink
+                to={{
+                  pathname: `/account/${block?.body.proposer ?? ''}`,
+                }}>
                 {withSkeletonLoading(
-                  <Hash
-                    hash={block?.header.state_root_hash ?? hashPlaceholder}
-                  />,
+                  <Hash hash={block?.body.proposer ?? hashPlaceholder} />,
                   isLoading,
                   { width: 850 },
                 )}
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('validator')}</DetailDataLabel>
-              <DetailDataValue height="2rem">
-                <StyledHashLink
-                  to={{
-                    pathname: `/account/${block?.body.proposer ?? ''}`,
-                  }}>
-                  {withSkeletonLoading(
-                    <Hash hash={block?.body.proposer ?? hashPlaceholder} />,
-                    isLoading,
-                    { width: 850 },
-                  )}
-                </StyledHashLink>
-                {!isLoading && (
-                  <CopyToClipboard textToCopy={block?.body.proposer ?? ''} />
-                )}
-              </DetailDataValue>
-            </li>
-          </DetailDataWrapper>
+              </StyledHashLink>
+              {!isLoading && (
+                <CopyToClipboard textToCopy={block?.body.proposer ?? ''} />
+              )}
+            </DetailDataValue>
+          </li>
+        </DetailDataWrapper>
 
-          <Spacer height="2.5rem" />
+        <Spacer height="2.5rem" />
 
-          <DetailDataRowWrapper>
-            <li>
-              <DetailDataLabel>{t('raw-data')}</DetailDataLabel>
-              <DetailDataValue>
-                <RawData rawData={rawBlock} />
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('deploys')}</DetailDataLabel>
-              <DetailDataValue isLargeText>
-                {withSkeletonLoading(
-                  block?.body.deploy_hashes?.length ? (
-                    <ul>
-                      {block?.body.deploy_hashes?.map(deployHash => (
-                        <li key={deployHash}>
-                          <StyledHashLink
-                            to={{ pathname: `/deploy/${deployHash}` }}>
-                            <Hash
-                              alwaysTruncate
-                              hash={deployHash ?? hashPlaceholder}
-                            />
-                          </StyledHashLink>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    t('no-deploys')
-                  ),
-                  isLoading,
-                  { width: 150 },
-                )}
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('transfers')}</DetailDataLabel>
-              <DetailDataValue isLargeText>
-                {withSkeletonLoading(
-                  block?.body.transfer_hashes?.length ? (
-                    <ul>
-                      {block?.body.transfer_hashes?.map(transferHash => (
-                        <li key={transferHash}>
-                          <StyledHashLink
-                            to={{ pathname: `/deploy/${transferHash}` }}>
-                            <Hash
-                              alwaysTruncate
-                              hash={transferHash ?? hashPlaceholder}
-                            />
-                          </StyledHashLink>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    t('no-transfers')
-                  ),
-                  isLoading,
-                  { width: 150 },
-                )}
-              </DetailDataValue>
-            </li>
-          </DetailDataRowWrapper>
-        </Card.Body>
-      </InfoCardContentWrapper>
+        <DetailDataRowWrapper>
+          <li>
+            <DetailDataLabel>{t('raw-data')}</DetailDataLabel>
+            <DetailDataValue>
+              <RawData rawData={rawBlock} />
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('deploys')}</DetailDataLabel>
+            <DetailDataValue isLargeText>
+              {withSkeletonLoading(
+                block?.body.deploy_hashes?.length ? (
+                  <ul>
+                    {block?.body.deploy_hashes?.map(deployHash => (
+                      <li key={deployHash}>
+                        <StyledHashLink
+                          to={{ pathname: `/deploy/${deployHash}` }}>
+                          <Hash
+                            alwaysTruncate
+                            hash={deployHash ?? hashPlaceholder}
+                          />
+                        </StyledHashLink>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  t('no-deploys')
+                ),
+                isLoading,
+                { width: 150 },
+              )}
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('transfers')}</DetailDataLabel>
+            <DetailDataValue isLargeText>
+              {withSkeletonLoading(
+                block?.body.transfer_hashes?.length ? (
+                  <ul>
+                    {block?.body.transfer_hashes?.map(transferHash => (
+                      <li key={transferHash}>
+                        <StyledHashLink
+                          to={{ pathname: `/deploy/${transferHash}` }}>
+                          <Hash
+                            alwaysTruncate
+                            hash={transferHash ?? hashPlaceholder}
+                          />
+                        </StyledHashLink>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  t('no-transfers')
+                ),
+                isLoading,
+                { width: 150 },
+              )}
+            </DetailDataValue>
+          </li>
+        </DetailDataRowWrapper>
+      </InfoCard>
     </>
   );
 };
-
 const HashWrapper = styled.div`
   display: flex;
   flex-direction: column;
 `;
-
 const HashHeading = styled(Heading)<{ isTruncated: boolean }>`
   font-weight: ${fontWeight.medium};
   display: inline;
@@ -240,25 +227,21 @@ const HashHeading = styled(Heading)<{ isTruncated: boolean }>`
   overflow-wrap: break-word;
   font-size: ${pxToRem(60)};
   color: ${props => props.theme.text.hash};
-  line-height: 1;
 `;
 
 const DetailDataRowWrapper = styled.ul`
   display: flex;
   flex-direction: column;
-
   @media only screen and (min-width: ${breakpoints.lg}) {
     flex-direction: row;
     gap: ${pxToRem(96)};
   }
 `;
-
 const PageHeading = styled.div`
   @media only screen and (min-width: ${breakpoints.lg}) {
     margin-bottom: 2rem;
   }
 `;
-
 const StyledHashLink = styled(Link)`
   color: ${props => props.theme.text.hash};
 `;

--- a/app/src/components/cards/BlockDetailsCard/MobileBlockDetailsCard.tsx
+++ b/app/src/components/cards/BlockDetailsCard/MobileBlockDetailsCard.tsx
@@ -5,8 +5,7 @@ import { Link } from 'react-router-dom';
 import { ApiData } from 'src/api/types';
 import { pxToRem } from 'src/styled-theme';
 import { hashPlaceholder } from 'src/utils';
-import { Card } from 'casper-ui-kit';
-import { InfoCardContentWrapper } from 'src/components/base';
+import { InfoCard } from '../../base';
 import {
   DetailDataLabel,
   DetailDataValue,
@@ -19,15 +18,12 @@ export interface MobileBlockDetailsCardProps {
   block: ApiData.Block | null;
   isLoading: boolean;
 }
-
 export const MobileBlockDetailsCard: React.FC<MobileBlockDetailsCardProps> = ({
   block,
   isLoading,
 }) => {
   const { t } = useTranslation();
-
   const rawBlock = JSON.stringify(block);
-
   return (
     <>
       <PageHeading>
@@ -38,181 +34,170 @@ export const MobileBlockDetailsCard: React.FC<MobileBlockDetailsCardProps> = ({
         )}
       </PageHeading>
 
-      <InfoCardContentWrapper>
-        <Card.Body>
-          <DetailDataRowWrapper>
-            <li>
-              <DetailDataLabel>{t('block-height')}</DetailDataLabel>
-              <DetailDataValue>
-                {withSkeletonLoading(block?.header.height, isLoading, {
-                  width: 100,
-                })}
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('current-era')}</DetailDataLabel>
-              <DetailDataValue>
-                {withSkeletonLoading(block?.header.era_id, isLoading, {
-                  width: 100,
-                })}
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('timestamp')}</DetailDataLabel>
-              <DetailDataValue>
+      <InfoCard>
+        <DetailDataRowWrapper>
+          <li>
+            <DetailDataLabel>{t('block-height')}</DetailDataLabel>
+            <DetailDataValue>
+              {withSkeletonLoading(block?.header.height, isLoading, {
+                width: 100,
+              })}
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('current-era')}</DetailDataLabel>
+            <DetailDataValue>
+              {withSkeletonLoading(block?.header.era_id, isLoading, {
+                width: 100,
+              })}
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('timestamp')}</DetailDataLabel>
+            <DetailDataValue>
+              {withSkeletonLoading(
+                block?.header.timestamp.toLocaleString(),
+                isLoading,
+                {
+                  width: 275,
+                },
+              )}
+            </DetailDataValue>
+          </li>
+        </DetailDataRowWrapper>
+      </InfoCard>
+      <InfoCard>
+        <DetailDataWrapper>
+          <li>
+            <DetailDataLabel>{t('parent-hash')}</DetailDataLabel>
+            <DetailDataValue height="2rem">
+              <StyledHashLink
+                to={{
+                  pathname: `/block/${block?.header.parent_hash ?? ''}`,
+                }}>
                 {withSkeletonLoading(
-                  block?.header.timestamp.toLocaleString(),
-                  isLoading,
-                  {
-                    width: 275,
-                  },
-                )}
-              </DetailDataValue>
-            </li>
-          </DetailDataRowWrapper>
-        </Card.Body>
-      </InfoCardContentWrapper>
-      <InfoCardContentWrapper>
-        <Card.Body>
-          <DetailDataWrapper>
-            <li>
-              <DetailDataLabel>{t('parent-hash')}</DetailDataLabel>
-              <DetailDataValue height="2rem">
-                <StyledHashLink
-                  to={{
-                    pathname: `/block/${block?.header.parent_hash ?? ''}`,
-                  }}>
-                  {withSkeletonLoading(
-                    <Hash
-                      hash={block?.header.parent_hash ?? hashPlaceholder}
-                    />,
-                    isLoading,
-                    {
-                      width: 175,
-                    },
-                  )}
-                </StyledHashLink>
-                {!isLoading && (
-                  <CopyToClipboard
-                    textToCopy={block?.header.parent_hash ?? hashPlaceholder}
-                  />
-                )}
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('block-hash')}</DetailDataLabel>
-              <DetailDataValue height="2rem">
-                {withSkeletonLoading(
-                  <Hash hash={block?.hash ?? hashPlaceholder} />,
+                  <Hash hash={block?.header.parent_hash ?? hashPlaceholder} />,
                   isLoading,
                   {
                     width: 175,
                   },
                 )}
-                {!isLoading && (
-                  <CopyToClipboard textToCopy={block?.hash ?? ''} />
-                )}
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('state-root-hash')}</DetailDataLabel>
-              <DetailDataValue>
+              </StyledHashLink>
+              {!isLoading && (
+                <CopyToClipboard
+                  textToCopy={block?.header.parent_hash ?? hashPlaceholder}
+                />
+              )}
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('block-hash')}</DetailDataLabel>
+            <DetailDataValue height="2rem">
+              {withSkeletonLoading(
+                <Hash hash={block?.hash ?? hashPlaceholder} />,
+                isLoading,
+                {
+                  width: 175,
+                },
+              )}
+              {!isLoading && <CopyToClipboard textToCopy={block?.hash ?? ''} />}
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('state-root-hash')}</DetailDataLabel>
+            <DetailDataValue>
+              {withSkeletonLoading(
+                <Hash
+                  hash={block?.header.state_root_hash ?? hashPlaceholder}
+                />,
+                isLoading,
+                {
+                  width: 175,
+                },
+              )}
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('validator')}</DetailDataLabel>
+            <DetailDataValue height="2rem">
+              <StyledHashLink
+                to={{
+                  pathname: `/account/${block?.body.proposer ?? ''}`,
+                }}>
                 {withSkeletonLoading(
-                  <Hash
-                    hash={block?.header.state_root_hash ?? hashPlaceholder}
-                  />,
+                  <Hash hash={block?.body.proposer ?? hashPlaceholder} />,
                   isLoading,
                   {
                     width: 175,
                   },
                 )}
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('validator')}</DetailDataLabel>
-              <DetailDataValue height="2rem">
-                <StyledHashLink
-                  to={{
-                    pathname: `/account/${block?.body.proposer ?? ''}`,
-                  }}>
-                  {withSkeletonLoading(
-                    <Hash hash={block?.body.proposer ?? hashPlaceholder} />,
-                    isLoading,
-                    {
-                      width: 175,
-                    },
-                  )}
-                </StyledHashLink>
-                {!isLoading && (
-                  <CopyToClipboard textToCopy={block?.body.proposer ?? ''} />
-                )}
-              </DetailDataValue>
-            </li>
-          </DetailDataWrapper>
-        </Card.Body>
-      </InfoCardContentWrapper>
-      <InfoCardContentWrapper>
-        <Card.Body>
-          <DetailDataWrapper>
-            <li>
-              <DetailDataLabel>{t('deploys')}</DetailDataLabel>
-              <DetailDataValue>
-                {withSkeletonLoading(
-                  block?.body.deploy_hashes?.length ? (
-                    <ul>
-                      {block?.body.deploy_hashes?.map(deployHash => (
-                        <li key={deployHash}>
-                          <StyledHashLink
-                            to={{ pathname: `/deploy/${deployHash}` }}>
-                            <Hash hash={deployHash} />
-                          </StyledHashLink>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    'No deploys'
-                  ),
-                  isLoading,
-                  { width: 150 },
-                )}
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('transfers')}</DetailDataLabel>
-              <DetailDataValue>
-                {withSkeletonLoading(
-                  block?.body.transfer_hashes?.length ? (
-                    <ul>
-                      {block?.body.transfer_hashes?.map(transferHash => (
-                        <li key={transferHash}>
-                          <StyledHashLink
-                            to={{ pathname: `/deploy/${transferHash}` }}>
-                            <Hash hash={transferHash} />
-                          </StyledHashLink>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    t('no-transfers')
-                  ),
-                  isLoading,
-                  { width: 150 },
-                )}
-              </DetailDataValue>
-            </li>
-            <li>
-              <DetailDataLabel>{t('raw-data')}</DetailDataLabel>
-              <DetailDataValue>
-                <RawData rawData={rawBlock} />
-              </DetailDataValue>
-            </li>
-          </DetailDataWrapper>
-        </Card.Body>
-      </InfoCardContentWrapper>
+              </StyledHashLink>
+              {!isLoading && (
+                <CopyToClipboard textToCopy={block?.body.proposer ?? ''} />
+              )}
+            </DetailDataValue>
+          </li>
+        </DetailDataWrapper>
+      </InfoCard>
+      <InfoCard>
+        <DetailDataWrapper>
+          <li>
+            <DetailDataLabel>{t('deploys')}</DetailDataLabel>
+            <DetailDataValue>
+              {withSkeletonLoading(
+                block?.body.deploy_hashes?.length ? (
+                  <ul>
+                    {block?.body.deploy_hashes?.map(deployHash => (
+                      <li key={deployHash}>
+                        <StyledHashLink
+                          to={{ pathname: `/deploy/${deployHash}` }}>
+                          <Hash hash={deployHash} />
+                        </StyledHashLink>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  'No deploys'
+                ),
+                isLoading,
+                { width: 150 },
+              )}
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('transfers')}</DetailDataLabel>
+            <DetailDataValue>
+              {withSkeletonLoading(
+                block?.body.transfer_hashes?.length ? (
+                  <ul>
+                    {block?.body.transfer_hashes?.map(transferHash => (
+                      <li key={transferHash}>
+                        <StyledHashLink
+                          to={{ pathname: `/deploy/${transferHash}` }}>
+                          <Hash hash={transferHash} />
+                        </StyledHashLink>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  t('no-transfers')
+                ),
+                isLoading,
+                { width: 150 },
+              )}
+            </DetailDataValue>
+          </li>
+          <li>
+            <DetailDataLabel>{t('raw-data')}</DetailDataLabel>
+            <DetailDataValue>
+              <RawData rawData={rawBlock} />
+            </DetailDataValue>
+          </li>
+        </DetailDataWrapper>
+      </InfoCard>
     </>
   );
 };
-
 const PageHeading = styled.h2`
   font-size: 2.2rem;
   margin-bottom: 1rem;
@@ -224,12 +209,10 @@ const PageHeading = styled.h2`
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 `;
-
 const DetailDataRowWrapper = styled(DetailDataWrapper)`
   display: flex;
   flex-wrap: wrap;
 `;
-
 const StyledHashLink = styled(Link)`
   color: ${props => props.theme.text.hash};
 `;

--- a/app/src/components/cards/DeployDetailsCard/DeployDetailsCard.tsx
+++ b/app/src/components/cards/DeployDetailsCard/DeployDetailsCard.tsx
@@ -5,10 +5,8 @@ import { useTranslation } from 'react-i18next';
 import { useAppWidth } from 'src/hooks';
 import { HashButton } from 'src/components/buttons';
 import { hashPlaceholder } from 'src/utils';
-import { Card } from 'casper-ui-kit';
-import { InfoCardContentWrapper } from 'src/components/base';
-import { Heading } from '../../base';
 import { Deploy } from '../../../api';
+import { Heading, InfoCard } from '../../base';
 import {
   Hash,
   DetailDataLabel,
@@ -16,7 +14,6 @@ import {
   DetailDataValue,
   DetailDataList,
 } from '../../styled';
-
 import { CopyToClipboard, RawData, withSkeletonLoading } from '../../utility';
 import { fontWeight, pxToRem } from '../../../styled-theme';
 
@@ -24,7 +21,6 @@ export interface DeployDetailsCardProps {
   deploy: Deploy | null;
   isLoading: boolean;
 }
-
 export const DeployDetailsCard: React.FC<DeployDetailsCardProps> = ({
   deploy,
   isLoading,
@@ -32,7 +28,6 @@ export const DeployDetailsCard: React.FC<DeployDetailsCardProps> = ({
   const [isTruncated, setIsTruncated] = useState(true);
   const { isMobile } = useAppWidth();
   const { t } = useTranslation();
-
   return (
     <>
       <HeaderContent>
@@ -59,80 +54,74 @@ export const DeployDetailsCard: React.FC<DeployDetailsCardProps> = ({
           )}
         </HashWrapper>
       </HeaderContent>
-      <InfoCardContentWrapper>
-        <Card.Body>
-          <DetailDataWrapper>
-            <DetailDataList>
-              <li>
-                <DetailDataLabel>{t('block-hash')}</DetailDataLabel>
-                <DetailDataValue height="2rem">
-                  {withSkeletonLoading(
-                    <>
-                      <StyledHashLink to={`/block/${deploy?.blockHash ?? ''}`}>
-                        <Hash hash={deploy?.blockHash ?? hashPlaceholder} />
-                      </StyledHashLink>
-                      <CopyToClipboard textToCopy={deploy?.blockHash ?? ''} />
-                    </>,
-                    isLoading,
-                    { width: '60%' },
-                  )}
-                </DetailDataValue>
-              </li>
-              <li>
-                <DetailDataLabel>{t('public-key')}</DetailDataLabel>
-                <DetailDataValue height="2rem">
-                  {withSkeletonLoading(
-                    <>
-                      <StyledHashLink
-                        to={`/account/${deploy?.publicKey ?? ''}`}>
-                        <Hash hash={deploy?.publicKey ?? hashPlaceholder} />
-                      </StyledHashLink>
-                      <CopyToClipboard textToCopy={deploy?.publicKey ?? ''} />
-                    </>,
-                    isLoading,
-                    { width: '60%' },
-                  )}
-                </DetailDataValue>
-              </li>
-              <li>
-                <DetailDataLabel>{t('deploy-hash')}</DetailDataLabel>
-                <DetailDataValue height="2rem">
-                  {withSkeletonLoading(
-                    <>
-                      <Hash hash={deploy?.deployHash ?? hashPlaceholder} />
-                      <CopyToClipboard textToCopy={deploy?.deployHash ?? ''} />
-                    </>,
-                    isLoading,
-                    { width: '60%' },
-                  )}
-                </DetailDataValue>
-              </li>
-              <li>
-                <DetailDataLabel>{t('raw-data')}</DetailDataLabel>
-                <DetailDataValue>
-                  {withSkeletonLoading(
-                    deploy?.rawDeploy && <RawData rawData={deploy.rawDeploy} />,
-                    isLoading,
-                    { width: 200, height: '2.25rem' },
-                  )}
-                </DetailDataValue>
-              </li>
-            </DetailDataList>
-          </DetailDataWrapper>
-        </Card.Body>
-      </InfoCardContentWrapper>
+      <InfoCard>
+        <DetailDataWrapper>
+          <DetailDataList>
+            <li>
+              <DetailDataLabel>{t('block-hash')}</DetailDataLabel>
+              <DetailDataValue height="2rem">
+                {withSkeletonLoading(
+                  <>
+                    <StyledHashLink to={`/block/${deploy?.blockHash ?? ''}`}>
+                      <Hash hash={deploy?.blockHash ?? hashPlaceholder} />
+                    </StyledHashLink>
+                    <CopyToClipboard textToCopy={deploy?.blockHash ?? ''} />
+                  </>,
+                  isLoading,
+                  { width: '60%' },
+                )}
+              </DetailDataValue>
+            </li>
+            <li>
+              <DetailDataLabel>{t('public-key')}</DetailDataLabel>
+              <DetailDataValue height="2rem">
+                {withSkeletonLoading(
+                  <>
+                    <StyledHashLink to={`/account/${deploy?.publicKey ?? ''}`}>
+                      <Hash hash={deploy?.publicKey ?? hashPlaceholder} />
+                    </StyledHashLink>
+                    <CopyToClipboard textToCopy={deploy?.publicKey ?? ''} />
+                  </>,
+                  isLoading,
+                  { width: '60%' },
+                )}
+              </DetailDataValue>
+            </li>
+            <li>
+              <DetailDataLabel>{t('deploy-hash')}</DetailDataLabel>
+              <DetailDataValue height="2rem">
+                {withSkeletonLoading(
+                  <>
+                    <Hash hash={deploy?.deployHash ?? hashPlaceholder} />
+                    <CopyToClipboard textToCopy={deploy?.deployHash ?? ''} />
+                  </>,
+                  isLoading,
+                  { width: '60%' },
+                )}
+              </DetailDataValue>
+            </li>
+            <li>
+              <DetailDataLabel>{t('raw-data')}</DetailDataLabel>
+              <DetailDataValue>
+                {withSkeletonLoading(
+                  deploy?.rawDeploy && <RawData rawData={deploy.rawDeploy} />,
+                  isLoading,
+                  { width: 200, height: '2.25rem' },
+                )}
+              </DetailDataValue>
+            </li>
+          </DetailDataList>
+        </DetailDataWrapper>
+      </InfoCard>
     </>
   );
 };
-
 const HeaderContent = styled.div``;
-
 const HashWrapper = styled.div`
   display: flex;
   flex-direction: column;
   min-height: ${pxToRem(75)};
 `;
-
 const HashHeading = styled(Heading)<{
   isTruncated: boolean;
   isMobile: boolean;
@@ -146,7 +135,6 @@ const HashHeading = styled(Heading)<{
   font-size: ${pxToRem(60)};
   color: ${props => props.theme.text.hash};
 `;
-
 const StyledHashLink = styled(Link)`
   color: ${props => props.theme.text.hash};
 `;

--- a/app/src/components/cards/TransactionDetailsCard/TransactionDetailsCard.tsx
+++ b/app/src/components/cards/TransactionDetailsCard/TransactionDetailsCard.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { useTranslation } from 'react-i18next';
-import { Icon, Card } from 'casper-ui-kit';
-import { InfoCardContentWrapper } from 'src/components/base';
+import { Icon } from 'casper-ui-kit';
 import {
   DetailDataLabel,
   DetailDataList,
@@ -13,7 +12,7 @@ import {
   HideOnMobile,
 } from '../../styled';
 import { breakpoints, fonts, fontWeight, pxToRem } from '../../../styled-theme';
-import { HeadContentWrapper, Heading } from '../../base';
+import { HeadContentWrapper, Heading, InfoCard } from '../../base';
 import { Coin, withSkeletonLoading } from '../../utility';
 import { Deploy, DeployStatus } from '../../../api';
 
@@ -21,13 +20,11 @@ interface TransactionDetailsCardProps {
   deploy: Deploy | null;
   isLoading: boolean;
 }
-
 export const TransactionDetailsCard: React.FC<TransactionDetailsCardProps> = ({
   deploy,
   isLoading,
 }) => {
   const { t } = useTranslation();
-
   const statusIcon =
     deploy?.status === DeployStatus.Success ? (
       <Icon icon="SuccessIcon" height={30} />
@@ -36,151 +33,137 @@ export const TransactionDetailsCard: React.FC<TransactionDetailsCardProps> = ({
     );
 
   return (
-    <InfoCardContentWrapper>
-      <Card.Body>
-        <HeadContentWrapper>
-          <TransactionHeading type="h2">
-            {t('transaction-details')}
-          </TransactionHeading>
-        </HeadContentWrapper>
-        <DetailDataWrapper>
-          <TransactionGrid gap="2rem">
-            <DetailDataList gap="2rem">
-              {!!deploy?.amount && (
-                <li>
-                  <Grid gap="1rem" templateColumns="9rem auto">
-                    <DetailDataLabel>{t('amount')}</DetailDataLabel>
-                    <DetailDataValue>
-                      <Coin>{deploy?.amount}</Coin>
-                    </DetailDataValue>
-                  </Grid>
-                </li>
-              )}
+    <InfoCard>
+      <HeadContentWrapper>
+        <TransactionHeading type="h2">
+          {t('transaction-details')}
+        </TransactionHeading>
+      </HeadContentWrapper>
+      <DetailDataWrapper>
+        <TransactionGrid gap="2rem">
+          <DetailDataList gap="2rem">
+            {!!deploy?.amount && (
               <li>
-                <Grid gap="1rem" templateColumns="9rem 1fr">
-                  <DetailDataLabel>{t('cost')}</DetailDataLabel>
+                <Grid gap="1rem" templateColumns="9rem auto">
+                  <DetailDataLabel>{t('amount')}</DetailDataLabel>
                   <DetailDataValue>
-                    {withSkeletonLoading(
-                      <Coin>{deploy?.cost ?? ''}</Coin>,
-                      isLoading,
-                      {},
-                    )}
+                    <Coin>{deploy?.amount}</Coin>
                   </DetailDataValue>
                 </Grid>
               </li>
-              <li>
-                <Grid gap="1rem" templateColumns="9rem 1fr">
-                  <DetailDataLabel>{t('payment-amount')}</DetailDataLabel>
-                  <DetailDataValue>
-                    {withSkeletonLoading(
-                      <Coin>{deploy?.paymentAmount ?? ''}</Coin>,
-                      isLoading,
-                      {},
-                    )}
-                  </DetailDataValue>
-                </Grid>
-              </li>
-            </DetailDataList>
-            <Grid templateColumns="1fr 1fr" templateRows="1fr" gap="2rem 1rem">
-              <div>
-                <DetailDataLabel>{t('timestamp')}</DetailDataLabel>
-                <TransactionDetailData>
+            )}
+            <li>
+              <Grid gap="1rem" templateColumns="9rem 1fr">
+                <DetailDataLabel>{t('cost')}</DetailDataLabel>
+                <DetailDataValue>
                   {withSkeletonLoading(
-                    deploy?.readableTimestamp,
+                    <Coin>{deploy?.cost ?? ''}</Coin>,
                     isLoading,
                     {},
                   )}
-                </TransactionDetailData>
+                </DetailDataValue>
+              </Grid>
+            </li>
+            <li>
+              <Grid gap="1rem" templateColumns="9rem 1fr">
+                <DetailDataLabel>{t('payment-amount')}</DetailDataLabel>
+                <DetailDataValue>
+                  {withSkeletonLoading(
+                    <Coin>{deploy?.paymentAmount ?? ''}</Coin>,
+                    isLoading,
+                    {},
+                  )}
+                </DetailDataValue>
+              </Grid>
+            </li>
+          </DetailDataList>
+          <Grid templateColumns="1fr 1fr" templateRows="1fr" gap="2rem 1rem">
+            <div>
+              <DetailDataLabel>{t('timestamp')}</DetailDataLabel>
+              <TransactionDetailData>
+                {withSkeletonLoading(deploy?.readableTimestamp, isLoading, {})}
+              </TransactionDetailData>
+            </div>
+            <HideOnMobile>
+              <div>
+                <DetailDataLabel>{t('status')}</DetailDataLabel>
+                <DeployStatusData>
+                  {withSkeletonLoading(
+                    <>
+                      {deploy?.status}
+                      <StatusIconWrapper>{statusIcon}</StatusIconWrapper>
+                    </>,
+                    isLoading,
+                    {},
+                  )}
+                </DeployStatusData>
               </div>
-              <HideOnMobile>
-                <div>
-                  <DetailDataLabel>{t('status')}</DetailDataLabel>
-                  <DeployStatusData>
-                    {withSkeletonLoading(
-                      <>
-                        {deploy?.status}
-                        <StatusIconWrapper>{statusIcon}</StatusIconWrapper>
-                      </>,
-                      isLoading,
-                      {},
-                    )}
-                  </DeployStatusData>
-                </div>
-              </HideOnMobile>
-              <HideOnDesktop>
-                <SpanTwoCols>
-                  <DetailDataLabel>{t('status')}</DetailDataLabel>
-                  <DeployStatusData>
-                    {withSkeletonLoading(
-                      <>
-                        {deploy?.status}
-                        <StatusIconWrapper>{statusIcon}</StatusIconWrapper>
-                      </>,
-                      isLoading,
-                      { width: 100 },
-                    )}
-                  </DeployStatusData>
-                </SpanTwoCols>
-              </HideOnDesktop>
+            </HideOnMobile>
+            <HideOnDesktop>
+              <SpanTwoCols>
+                <DetailDataLabel>{t('status')}</DetailDataLabel>
+                <DeployStatusData>
+                  {withSkeletonLoading(
+                    <>
+                      {deploy?.status}
+                      <StatusIconWrapper>{statusIcon}</StatusIconWrapper>
+                    </>,
+                    isLoading,
+                    { width: 100 },
+                  )}
+                </DeployStatusData>
+              </SpanTwoCols>
+            </HideOnDesktop>
+            <ActionAndDeployTypeWrapper>
+              <DetailDataLabel>{t('action')}</DetailDataLabel>
+              <TransactionDetailData>
+                {withSkeletonLoading(deploy?.action, isLoading, {})}
+              </TransactionDetailData>
+            </ActionAndDeployTypeWrapper>
+            {!!deploy?.deployType && (
               <ActionAndDeployTypeWrapper>
-                <DetailDataLabel>{t('action')}</DetailDataLabel>
+                <DetailDataLabel>{t('deploy-type')}</DetailDataLabel>
                 <TransactionDetailData>
-                  {withSkeletonLoading(deploy?.action, isLoading, {})}
+                  {deploy?.deployType}
                 </TransactionDetailData>
               </ActionAndDeployTypeWrapper>
-              {!!deploy?.deployType && (
-                <ActionAndDeployTypeWrapper>
-                  <DetailDataLabel>{t('deploy-type')}</DetailDataLabel>
-                  <TransactionDetailData>
-                    {deploy?.deployType}
-                  </TransactionDetailData>
-                </ActionAndDeployTypeWrapper>
-              )}
-            </Grid>
-          </TransactionGrid>
-        </DetailDataWrapper>
-      </Card.Body>
-    </InfoCardContentWrapper>
+            )}
+          </Grid>
+        </TransactionGrid>
+      </DetailDataWrapper>
+    </InfoCard>
   );
 };
 
 const TransactionGrid = styled(Grid)`
   grid-template-columns: 1fr;
-
   @media only screen and (min-width: ${breakpoints.lg}) {
     grid-template-columns: 1fr 1fr;
   }
 `;
-
 const TransactionHeading = styled(Heading)`
   font-size: ${pxToRem(18)};
   font-weight: ${fontWeight.medium};
   color: ${props => props.theme.text.primary};
 `;
-
 const TransactionDetailData = styled.div`
   font-size: ${pxToRem(26)};
   color: ${props => props.theme.text.primary};
 `;
-
 const DeployStatusData = styled(TransactionDetailData)`
   display: flex;
   gap: 0.75rem;
 `;
-
 const SpanTwoCols = styled(TransactionDetailData)`
   grid-column: span 2;
 `;
-
 const ActionAndDeployTypeWrapper = styled(SpanTwoCols)`
   flex-direction: column;
   font-family: ${fonts.secondaryFont};
-
   div {
     font-size: ${pxToRem(24)};
   }
 `;
-
 const StatusIconWrapper = styled.span`
   display: block;
   width: 1.875rem;


### PR DESCRIPTION
### 🔥 Summary
The Casper UI Kit Card Component is not rendering any content at the moment in prod environments.  Unfortunately this bug is currently live in release 1.3.0.

This ticket reverts the changes made to refactor the block explorer to use the ui kit card

We will need to create a hot fix release while we debug the issue.
