### PR TITLE
feat: add rawData to theme

### DIFF
--- a/app/src/components/utility/RawData/RawData.tsx
+++ b/app/src/components/utility/RawData/RawData.tsx
@@ -11,6 +11,8 @@ import {
 } from 'react-accessible-accordion';
 import { pxToRem, defaultTheme } from 'casper-ui-kit';
 import styled from '@emotion/styled';
+import { useTheme } from '@emotion/react';
+import { darkTheme, lightTheme } from 'src/theme';
 
 interface RawDataProps {
   readonly rawData: string;
@@ -26,6 +28,47 @@ export const RawData: React.FC<RawDataProps> = ({ rawData }) => {
   const { t } = useTranslation();
   const rawDataJSON: object = parseJSON(rawData);
 
+  const { type: themeType } = useTheme();
+
+  const rawDataBackgroundColor =
+    themeType === 'light'
+      ? lightTheme.rawData.background
+      : darkTheme.rawData.background;
+
+  const rawDataKeyValStrings =
+    themeType === 'light'
+      ? lightTheme.rawData.keyValString
+      : darkTheme.rawData.keyValString;
+
+  const rawDataNumberOfItemsAndArrayIndices =
+    themeType === 'light'
+      ? lightTheme.rawData.itemsArrayIndices
+      : darkTheme.rawData.itemsArrayIndices;
+
+  const rawDataSvgAndNestedVal =
+    themeType === 'light' ? lightTheme.text.warning : darkTheme.text.warning;
+
+  const rawDataTheme = {
+    base00: `${rawDataBackgroundColor}`,
+    base01: `${rawDataBackgroundColor}`,
+    base02: `${rawDataBackgroundColor}`,
+    base03: `${rawDataKeyValStrings}`,
+    base04: `${rawDataNumberOfItemsAndArrayIndices}`,
+    base05: `${rawDataKeyValStrings}`,
+    base06: `${rawDataKeyValStrings}`,
+    base07: `${rawDataKeyValStrings}`,
+    base08: `${rawDataKeyValStrings}`,
+    base09: `${rawDataKeyValStrings}`,
+    base0A: `${rawDataNumberOfItemsAndArrayIndices}`,
+    base0B: `${rawDataKeyValStrings}`,
+    base0C: `${rawDataNumberOfItemsAndArrayIndices}`,
+    base0D: `${rawDataSvgAndNestedVal}`,
+    base0E: `${rawDataSvgAndNestedVal}`,
+    base0F: `${rawDataSvgAndNestedVal}`,
+  };
+
+  // More on base roles at: https://github.com/chriskempson/base16/blob/main/styling.md
+
   return (
     <Accordion allowZeroExpanded>
       <AccordionItem>
@@ -40,7 +83,12 @@ export const RawData: React.FC<RawDataProps> = ({ rawData }) => {
         </AccordionItemHeading>
         <AccordionItemPanel>
           <CodeBackground>
-            <ReactJson src={rawDataJSON} displayDataTypes={false} collapsed />
+            <ReactJson
+              src={rawDataJSON}
+              displayDataTypes={false}
+              collapsed
+              theme={rawDataTheme}
+            />
           </CodeBackground>
         </AccordionItemPanel>
       </AccordionItem>
@@ -74,8 +122,4 @@ const CodeBackground = styled.div`
   border-radius: 0.5rem;
   margin-top: 1.5rem;
   background-color: ${props => props.theme.background.secondary};
-
-  * {
-    color: ${props => props.theme.text.primary};
-  }
 `;

--- a/app/src/theme.ts
+++ b/app/src/theme.ts
@@ -21,6 +21,12 @@ export const lightTheme = {
     warning: lightColors.mediumWarning,
     hover: lightColors.primary,
   },
+  rawData: {
+    keyValString: lightColors.black,
+    background: lightColors.secondary,
+    svgNestVal: lightColors.mediumWarning,
+    itemsArrayIndices: lightColors.primary,
+  },
   selected: {
     primary: lightColors.lightSupporting,
   },
@@ -45,6 +51,12 @@ export const darkTheme = {
     warning: darkColors.mediumWarning,
     success: darkColors.success,
     hover: darkColors.primary,
+  },
+  rawData: {
+    keyValString: darkColors.white,
+    background: darkColors.secondary,
+    svgNestVal: darkColors.mediumWarning,
+    itemsArrayIndices: darkColors.primary,
   },
   selected: {
     primary: darkColors.lightSupporting,

--- a/app/src/types/theme.d.ts
+++ b/app/src/types/theme.d.ts
@@ -23,6 +23,12 @@ declare module '@emotion/react' {
       success: string;
       hover: string;
     };
+    rawData: {
+      keyValString: string;
+      background: string;
+      svgNestVal: string;
+      itemsArrayIndices: string;
+    };
     selected: {
       primary: string;
     };


### PR DESCRIPTION
🔥 Summary
<img width="1277" alt="Screenshot 2023-05-15 at 11 21 56 AM" src="https://github.com/casper-network/casper-blockexplorer-frontend/assets/88854201/85829653-03f0-4e1a-b3d1-533cbf7f4d81">
<img width="1128" alt="Screenshot 2023-05-15 at 11 21 45 AM" src="https://github.com/casper-network/casper-blockexplorer-frontend/assets/88854201/0cf06dfc-5476-41d5-90a9-1923b0916e82">

 😤 Problem / Goals
- Some raw data items were not fully visible in dark mode.  https://github.com/casper-network/casper-blockexplorer-frontend/issues/303

 🤓 Solution
-Add custom theme raw data

