### PR TITLE
fix: update audit ignore

### DIFF
--- a/app/.nsprc
+++ b/app/.nsprc
@@ -3,5 +3,10 @@
     "active": true,
     "notes": "Ignored until css-minimizer-webpack-plugin, postcss-loader, & fork-ts-checker-webpack-plugin add a fix.",
     "expiry": "1 May 2023 9:00 am"
+  },
+  "1092099": {
+    "active": true,
+    "notes": "Ignore temporarily while we find a fix for socket.io-parser",
+    "expiry": "1 July 2023 9:00 am"
   }
 }


### PR DESCRIPTION
### 🔥 Summary
- Adds socket.io-parser to audit ignore. We are finding that npm audit does not trigger a warning but better npm audit  causes an error. See: https://github.com/advisories/GHSA-cqmj-92xf-r6r9

### 📹 Video

### 😤 Problem / Goals
-

### 🤓 Solution
-

### 🗒️ Additional Notes
-
