### PR TITLE
fix: socket.io vulnerability

### DIFF
--- a/app/.nsprc
+++ b/app/.nsprc
@@ -1,12 +1,7 @@
 {
   "1091814": {
-    "active": true,
+    "active": false,
     "notes": "Ignored until css-minimizer-webpack-plugin, postcss-loader, & fork-ts-checker-webpack-plugin add a fix.",
     "expiry": "1 May 2023 9:00 am"
-  },
-  "1092099": {
-    "active": true,
-    "notes": "Ignore temporarily while we find a fix for socket.io-parser",
-    "expiry": "1 July 2023 9:00 am"
   }
 }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -18083,9 +18083,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.2.tgz",
-      "integrity": "sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.3.tgz",
+      "integrity": "sha512-JMafRntWVO2DCJimKsRTh/wnqVvO4hrfwOqtO7f+uzwsQMuxO6VwImtYxaQ+ieoyshWOTJyV0fA21lccEXRPpQ==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"


### PR DESCRIPTION
### 🔥 Summary
Bump minor version of sub dependency with `npm audit fix` & remove better npm audit ignore
