### PR TITLE
Fix/expanded rawdata sidescroll

### DIFF
--- a/app/src/components/cards/BlockDetailsCard/BlockDetailsCard.tsx
+++ b/app/src/components/cards/BlockDetailsCard/BlockDetailsCard.tsx
@@ -262,6 +262,7 @@ const DetailDataRowWrapper = styled.ul`
   @media only screen and (min-width: ${defaultTheme.typography.breakpoints
       .lg}) {
     flex-direction: row;
+    flex-wrap: wrap;
     gap: ${pxToRem(96)};
   }
 `;

--- a/app/src/components/cards/DeployDetailsCard/DeployDetailsCard.tsx
+++ b/app/src/components/cards/DeployDetailsCard/DeployDetailsCard.tsx
@@ -148,6 +148,7 @@ const HashHeading = styled(Heading)<{
   overflow-wrap: none;
   font-size: ${pxToRem(60)};
   color: ${props => props.theme.text.hash};
+  line-height: ${({ isTruncated }) => (isTruncated ? '4.1rem' : '3.5rem')};
 
   @media (min-width: ${defaultTheme.typography.breakpoints.lg}) {
     overflow-wrap: break-word;

--- a/app/src/components/utility/RawData/RawData.tsx
+++ b/app/src/components/utility/RawData/RawData.tsx
@@ -13,7 +13,11 @@ import { pxToRem, defaultTheme } from 'casper-ui-kit';
 import styled from '@emotion/styled';
 import { useTheme } from '@emotion/react';
 import { darkTheme, lightTheme } from 'src/theme';
-import { MOBILE_BREAKPOINT } from 'src/constants';
+import {
+  DESKTOP_RAW_DATA_STRING_LENGTH_COEFFICIENT,
+  MOBILE_BREAKPOINT,
+  MOBILE_RAW_DATA_STRING_LENGTH_COEFFICIENT,
+} from 'src/constants';
 
 interface RawDataProps {
   readonly rawData: string;
@@ -34,10 +38,14 @@ export const RawData: React.FC<RawDataProps> = ({ rawData }) => {
 
   useEffect(() => {
     if (windowWidth <= MOBILE_BREAKPOINT) {
-      const MobileRawDataStringLength = Math.floor(windowWidth * 0.035);
+      const MobileRawDataStringLength = Math.floor(
+        windowWidth * MOBILE_RAW_DATA_STRING_LENGTH_COEFFICIENT,
+      );
       setStringLength(MobileRawDataStringLength);
     } else {
-      const DesktopRawDataStringLength = Math.floor(windowWidth * 0.0595);
+      const DesktopRawDataStringLength = Math.floor(
+        windowWidth * DESKTOP_RAW_DATA_STRING_LENGTH_COEFFICIENT,
+      );
       setStringLength(DesktopRawDataStringLength);
     }
   }, [windowWidth]);

--- a/app/src/components/utility/RawData/RawData.tsx
+++ b/app/src/components/utility/RawData/RawData.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactJson from '@microlink/react-json-view';
 import { useTranslation } from 'react-i18next';
 import {
@@ -13,6 +13,7 @@ import { pxToRem, defaultTheme } from 'casper-ui-kit';
 import styled from '@emotion/styled';
 import { useTheme } from '@emotion/react';
 import { darkTheme, lightTheme } from 'src/theme';
+import { MOBILE_BREAKPOINT } from 'src/constants';
 
 interface RawDataProps {
   readonly rawData: string;
@@ -27,6 +28,20 @@ const parseJSON = (JSONString: string) => {
 export const RawData: React.FC<RawDataProps> = ({ rawData }) => {
   const { t } = useTranslation();
   const rawDataJSON: object = parseJSON(rawData);
+  const [stringLength, setStringLength] = useState<number>();
+
+  const windowWidth = window.innerWidth;
+
+  useEffect(() => {
+    if (windowWidth <= MOBILE_BREAKPOINT) {
+      const phoneAndTabletRawDataStringLength = Math.floor(windowWidth * 0.035);
+      setStringLength(phoneAndTabletRawDataStringLength);
+    } else {
+      const DesktopRawDataStringLength = Math.floor(windowWidth * 0.06);
+      setStringLength(DesktopRawDataStringLength);
+    }
+  }, [windowWidth]);
+
   const { type: themeType } = useTheme();
 
   const rawDataBackgroundColor =
@@ -87,6 +102,7 @@ export const RawData: React.FC<RawDataProps> = ({ rawData }) => {
               displayDataTypes={false}
               collapsed
               theme={rawDataTheme}
+              collapseStringsAfterLength={stringLength}
             />
           </CodeBackground>
         </AccordionItemPanel>

--- a/app/src/components/utility/RawData/RawData.tsx
+++ b/app/src/components/utility/RawData/RawData.tsx
@@ -34,10 +34,10 @@ export const RawData: React.FC<RawDataProps> = ({ rawData }) => {
 
   useEffect(() => {
     if (windowWidth <= MOBILE_BREAKPOINT) {
-      const phoneAndTabletRawDataStringLength = Math.floor(windowWidth * 0.035);
-      setStringLength(phoneAndTabletRawDataStringLength);
+      const MobileRawDataStringLength = Math.floor(windowWidth * 0.035);
+      setStringLength(MobileRawDataStringLength);
     } else {
-      const DesktopRawDataStringLength = Math.floor(windowWidth * 0.06);
+      const DesktopRawDataStringLength = Math.floor(windowWidth * 0.0595);
       setStringLength(DesktopRawDataStringLength);
     }
   }, [windowWidth]);
@@ -133,8 +133,12 @@ const RawDataToggleButton = styled(AccordionItemButton)`
 `;
 
 const CodeBackground = styled.div`
-  padding: 1.5rem;
+  padding: 1.5rem 0.1rem;
   border-radius: 0.5rem;
   margin-top: 1.5rem;
   background-color: ${props => props.theme.background.secondary};
+
+  @media (min-width: ${defaultTheme.typography.breakpoints.xs}) {
+    padding: 1.5rem;
+  }
 `;

--- a/app/src/components/utility/RawData/RawData.tsx
+++ b/app/src/components/utility/RawData/RawData.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import ReactJson from '@microlink/react-json-view';
 import { useTranslation } from 'react-i18next';
 import {
@@ -13,11 +13,6 @@ import { pxToRem, defaultTheme } from 'casper-ui-kit';
 import styled from '@emotion/styled';
 import { useTheme } from '@emotion/react';
 import { darkTheme, lightTheme } from 'src/theme';
-import {
-  DESKTOP_RAW_DATA_STRING_LENGTH_COEFFICIENT,
-  MOBILE_BREAKPOINT,
-  MOBILE_RAW_DATA_STRING_LENGTH_COEFFICIENT,
-} from 'src/constants';
 
 interface RawDataProps {
   readonly rawData: string;
@@ -32,23 +27,6 @@ const parseJSON = (JSONString: string) => {
 export const RawData: React.FC<RawDataProps> = ({ rawData }) => {
   const { t } = useTranslation();
   const rawDataJSON: object = parseJSON(rawData);
-  const [stringLength, setStringLength] = useState<number>();
-
-  const windowWidth = window.innerWidth;
-
-  useEffect(() => {
-    if (windowWidth <= MOBILE_BREAKPOINT) {
-      const MobileRawDataStringLength = Math.floor(
-        windowWidth * MOBILE_RAW_DATA_STRING_LENGTH_COEFFICIENT,
-      );
-      setStringLength(MobileRawDataStringLength);
-    } else {
-      const DesktopRawDataStringLength = Math.floor(
-        windowWidth * DESKTOP_RAW_DATA_STRING_LENGTH_COEFFICIENT,
-      );
-      setStringLength(DesktopRawDataStringLength);
-    }
-  }, [windowWidth]);
 
   const { type: themeType } = useTheme();
 
@@ -110,7 +88,6 @@ export const RawData: React.FC<RawDataProps> = ({ rawData }) => {
               displayDataTypes={false}
               collapsed
               theme={rawDataTheme}
-              collapseStringsAfterLength={stringLength}
             />
           </CodeBackground>
         </AccordionItemPanel>
@@ -141,10 +118,15 @@ const RawDataToggleButton = styled(AccordionItemButton)`
 `;
 
 const CodeBackground = styled.div`
-  padding: 1.5rem 0.1rem;
+  padding: 1.5rem 0.5rem;
   border-radius: 0.5rem;
   margin-top: 1.5rem;
   background-color: ${props => props.theme.background.secondary};
+
+  .react-json-view {
+    word-break: break-all;
+    -ms-word-break: break-all;
+  }
 
   @media (min-width: ${defaultTheme.typography.breakpoints.xs}) {
     padding: 1.5rem;

--- a/app/src/components/utility/RawData/RawData.tsx
+++ b/app/src/components/utility/RawData/RawData.tsx
@@ -125,7 +125,6 @@ const CodeBackground = styled.div`
 
   .react-json-view {
     word-break: break-all;
-    -ms-word-break: break-all;
   }
 
   @media (min-width: ${defaultTheme.typography.breakpoints.xs}) {

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -10,3 +10,5 @@ export const DEFAULT_FONT_URL = '';
 export const DEFAULT_PRIMARY_FONT_FAMILIES = 'Inter, sans-serif';
 export const DEFAULT_SECONDARY_FONT_FAMILIES = 'JetBrains Mono, monospace';
 export const DEFAULT_PAGESIZE = 10;
+export const MOBILE_RAW_DATA_STRING_LENGTH_COEFFICIENT = 0.035;
+export const DESKTOP_RAW_DATA_STRING_LENGTH_COEFFICIENT = 0.059;

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -10,5 +10,3 @@ export const DEFAULT_FONT_URL = '';
 export const DEFAULT_PRIMARY_FONT_FAMILIES = 'Inter, sans-serif';
 export const DEFAULT_SECONDARY_FONT_FAMILIES = 'JetBrains Mono, monospace';
 export const DEFAULT_PAGESIZE = 10;
-export const MOBILE_RAW_DATA_STRING_LENGTH_COEFFICIENT = 0.035;
-export const DESKTOP_RAW_DATA_STRING_LENGTH_COEFFICIENT = 0.059;


### PR DESCRIPTION
🔥 Summary
<img width="1578" alt="string-length" src="https://github.com/casper-network/casper-blockexplorer-frontend/assets/88854201/06b7ea89-372a-42e0-b5d3-72c89b143a71">
<img width="947" alt="string-length-tablet" src="https://github.com/casper-network/casper-blockexplorer-frontend/assets/88854201/12e7c6d2-6924-4b52-85af-4d7e45dd8092">
![google](https://github.com/casper-network/casper-blockexplorer-frontend/assets/88854201/bfe98623-73e3-4ad7-8519-de62caa72582)


Update RawData display for mobile and desktop and fix l/r scrolling issue when RawData display is open https://github.com/casper-network/casper-blockexplorer-frontend/issues/321


