### PR TITLE
feat-327: listen for updated peers and validators info using WS

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -27,6 +27,7 @@ import {
   updateLatestBlock,
   initializeSocket,
   updateCurrentEraValidatorsStatus,
+  updateTotalPeers,
 } from './store';
 
 import { loadConfig } from './utils';
@@ -74,6 +75,7 @@ const App = () => {
         dispatch(updateLatestBlock(latestBlock));
       });
 
+      // TODO: refactor to add to a WS class and add generic typing - 327b
       socket.on(
         'current_era_validator_status',
         (currentEraValidatorStatusString: string) => {
@@ -89,6 +91,20 @@ const App = () => {
           dispatch(updateCurrentEraValidatorsStatus(currentEraValidatorStatus));
         },
       );
+
+      socket.on('peers', (peersString: string) => {
+        const parsedPeers = JSON.parse(peersString) as {
+          peers: { totalPeers: number };
+        }[];
+
+        const [
+          {
+            peers: { totalPeers },
+          },
+        ] = parsedPeers;
+
+        dispatch(updateTotalPeers(totalPeers));
+      });
     }
   }, [socket, dispatch]);
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -26,6 +26,7 @@ import {
   getSocket,
   updateLatestBlock,
   initializeSocket,
+  updateCurrentEraValidatorsStatus,
 } from './store';
 
 import { loadConfig } from './utils';
@@ -72,6 +73,22 @@ const App = () => {
 
         dispatch(updateLatestBlock(latestBlock));
       });
+
+      socket.on(
+        'current_era_validator_status',
+        (currentEraValidatorStatusString: string) => {
+          const parsedcurrentEraValidatorStatus = JSON.parse(
+            currentEraValidatorStatusString,
+          ) as {
+            currentEraValidatorStatus: ApiData.CurrentEraValidatorStatus;
+          }[];
+
+          const [{ currentEraValidatorStatus }] =
+            parsedcurrentEraValidatorStatus;
+
+          dispatch(updateCurrentEraValidatorsStatus(currentEraValidatorStatus));
+        },
+      );
     }
   }, [socket, dispatch]);
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -79,14 +79,14 @@ const App = () => {
       socket.on(
         'current_era_validator_status',
         (currentEraValidatorStatusString: string) => {
-          const parsedcurrentEraValidatorStatus = JSON.parse(
+          const parsedCurrentEraValidatorStatus = JSON.parse(
             currentEraValidatorStatusString,
           ) as {
             currentEraValidatorStatus: ApiData.CurrentEraValidatorStatus;
           }[];
 
           const [{ currentEraValidatorStatus }] =
-            parsedcurrentEraValidatorStatus;
+            parsedCurrentEraValidatorStatus;
 
           dispatch(updateCurrentEraValidatorsStatus(currentEraValidatorStatus));
         },

--- a/app/src/store/slices/peer-slice.ts
+++ b/app/src/store/slices/peer-slice.ts
@@ -82,6 +82,9 @@ export const peerSlice = createSlice({
     ) => {
       state.tableOptions.sorting = action.payload;
     },
+    updateTotalPeers: (state, action: PayloadAction<number>) => {
+      state.totalPeers = action.payload;
+    },
   },
   extraReducers(builder) {
     builder
@@ -110,8 +113,12 @@ export const peerSlice = createSlice({
   },
 });
 
-export const { setPeerTableOptions, updatePeerPageNum, updatePeerSorting } =
-  peerSlice.actions;
+export const {
+  setPeerTableOptions,
+  updatePeerPageNum,
+  updatePeerSorting,
+  updateTotalPeers,
+} = peerSlice.actions;
 
 peerListener.startListening({
   matcher: isAnyOf(setPeerTableOptions, updatePeerPageNum, updatePeerSorting),

--- a/app/src/store/slices/validator-slice.ts
+++ b/app/src/store/slices/validator-slice.ts
@@ -105,6 +105,12 @@ export const validatorSlice = createSlice({
       state.tableOptions = defaultTableOptions;
     },
     resetToInitialValidatorState: () => initialState,
+    updateCurrentEraValidatorsStatus: (
+      state,
+      action: PayloadAction<ApiData.CurrentEraValidatorStatus>,
+    ) => {
+      state.currentEraValidatorStatus = action.payload;
+    },
   },
   extraReducers(builder) {
     builder
@@ -146,6 +152,7 @@ export const {
   updateValidatorSorting,
   resetValidatorTableOptions,
   resetToInitialValidatorState,
+  updateCurrentEraValidatorsStatus,
 } = validatorSlice.actions;
 
 validatorListener.startListening({


### PR DESCRIPTION
### 🔥 Summary
https://github.com/casper-network/casper-blockexplorer-frontend/issues/327

### 📹 Video

### 😤 Problem / Goals
-

### 🤓 Solution
-

### 🗒️ Additional Notes
-
