### PR TITLE
feat-329: add testing library for mock sockets and basic tests

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -38,6 +38,7 @@
         "react-select-event": "^5.5.1",
         "react-use-measure": "^2.1.1",
         "socket.io-client": "^4.6.1",
+        "socket.io-mock-ts": "^1.0.2",
         "swiper": "^8.4.2",
         "use-async-effect": "^2.2.6",
         "web-vitals": "^2.1.4"
@@ -4633,6 +4634,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/component-emitter": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
+      "integrity": "sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ=="
+    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -6942,6 +6948,11 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -18080,6 +18091,15 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-mock-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/socket.io-mock-ts/-/socket.io-mock-ts-1.0.2.tgz",
+      "integrity": "sha512-0XqMcm6+wDIPRBss3KDoRXV+Fcf4nissrHw9z9So4ZyWwwtKKSaj1gsvrJyGvYbhH+cGWeVgQx6KpaybgSp4hw==",
+      "dependencies": {
+        "@types/component-emitter": "^1.2.11",
+        "component-emitter": "^1.3.0"
       }
     },
     "node_modules/socket.io-parser": {

--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,7 @@
     "react-select-event": "^5.5.1",
     "react-use-measure": "^2.1.1",
     "socket.io-client": "^4.6.1",
+    "socket.io-mock-ts": "^1.0.2",
     "swiper": "^8.4.2",
     "use-async-effect": "^2.2.6",
     "web-vitals": "^2.1.4"

--- a/app/src/api/socket.test.tsx
+++ b/app/src/api/socket.test.tsx
@@ -1,0 +1,39 @@
+import { SocketServerMock } from 'socket.io-mock-ts';
+import { Home } from 'src/pages';
+import { render } from 'src/test-utils';
+
+jest.mock('socket.io-client');
+
+const mockMessage = 'message from server';
+
+describe('Socket connection', () => {
+  let socket: SocketServerMock;
+
+  beforeEach(() => {
+    socket = new SocketServerMock();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should connect to mock server', () => {
+    render(<Home />);
+
+    expect(socket.clientMock.connected).toBeTruthy();
+  });
+
+  it('should listen for data from mock server', async () => {
+    render(<Home />);
+
+    const data = await new Promise(resolve => {
+      socket.on('message', (message: string) => {
+        resolve(message);
+      });
+
+      socket.clientMock.emit('message', mockMessage);
+    });
+
+    expect(data).toBe(mockMessage);
+  });
+});

--- a/app/src/api/socket.test.tsx
+++ b/app/src/api/socket.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { SocketServerMock } from 'socket.io-mock-ts';
 import { Home } from 'src/pages';
 import { render } from 'src/test-utils';


### PR DESCRIPTION
### 🔥 Summary
https://github.com/casper-network/casper-blockexplorer-frontend/issues/329

### 📹 Video

### 😤 Problem / Goals
-

### 🤓 Solution
-

### 🗒️ Additional Notes
-
