### PR TITLE
feat-347: add count of deploy and transfer hashes for deploy count on blocks table

### DIFF
--- a/app/src/components/tables/BlockTable/BlocksTable.tsx
+++ b/app/src/components/tables/BlockTable/BlocksTable.tsx
@@ -136,8 +136,15 @@ export const BlocksTable: React.FC<BlocksTableProps> = ({
       },
       {
         header: `${t('deploy')}`,
-        accessorKey: 'body.deploy_hashes',
-        cell: ({ getValue }) => getValue<string[]>().length,
+        accessorKey: 'body',
+        cell: ({ getValue }) => {
+          const body = getValue<ApiData.Block['body']>();
+
+          return (
+            (body.deploy_hashes?.length ?? 0) +
+            (body.transfer_hashes?.length ?? 0)
+          );
+        },
         maxSize: 100,
         enableSorting: false,
       },


### PR DESCRIPTION
### 🔥 Summary
https://github.com/casper-network/casper-blockexplorer-frontend/issues/347

### 📹 Video

### 😤 Problem / Goals
-

### 🤓 Solution
-

### 🗒️ Additional Notes
-
