### PR TITLE
feat-349: add validators era toggle

### DIFF
--- a/app/src/api/api.ts
+++ b/app/src/api/api.ts
@@ -167,8 +167,6 @@ const createApi = (baseUrl: string) => {
           },
         );
 
-        console.log({ response });
-
         if (response.status !== 200) throw new Error(response.statusText);
 
         const {

--- a/app/src/api/api.ts
+++ b/app/src/api/api.ts
@@ -167,15 +167,17 @@ const createApi = (baseUrl: string) => {
           },
         );
 
+        console.log({ response });
+
         if (response.status !== 200) throw new Error(response.statusText);
 
         const {
           data: {
-            validators: { validators },
+            validators: { currentEraValidators, nextEraValidators },
           },
         } = response;
 
-        return validators;
+        return { currentEraValidators, nextEraValidators };
       },
       async getCurrentEraValidatorStatus() {
         type Response = AxiosResponse<ApiData.CurrentEraValidatorStatus>;

--- a/app/src/api/types.ts
+++ b/app/src/api/types.ts
@@ -97,7 +97,8 @@ export namespace ApiData {
   export interface Validators {
     validators: {
       status: CurrentEraValidatorStatus;
-      validators: ValidatorsInfo[];
+      currentEraValidators: ValidatorsInfo[];
+      nextEraValidators: ValidatorsInfo[];
     };
   }
 

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -18,6 +18,7 @@ import {
   useAppDispatch,
   useAppSelector,
   getNextEraValidators,
+  getLatestBlock,
 } from 'src/store';
 import { standardizeNumber, truncateHash } from 'src/utils';
 import { ApiData } from 'src/api/types';
@@ -45,6 +46,9 @@ export const ValidatorTable: React.FC = () => {
   );
   const validatorsTableOptions = useAppSelector(getValidatorsTableOptions);
   const totalEraValidators = useAppSelector(getTotalEraValidators);
+  const latestBlock = useAppSelector(getLatestBlock);
+
+  const currentEraId = latestBlock?.header.era_id;
 
   useEffect(() => {
     dispatch(fetchCurrentEraValidatorStatus());
@@ -169,13 +173,13 @@ export const ValidatorTable: React.FC = () => {
           type="button"
           onClick={() => setIsCurrentEra(true)}
           selected={isCurrentEra}>
-          Current Era
+          Current Era {currentEraId ?? ''}
         </EraToggleButton>
         <EraToggleButton
           type="button"
           selected={!isCurrentEra}
           onClick={() => setIsCurrentEra(false)}>
-          Era
+          Next Era {currentEraId ? currentEraId + 1 : ''}
         </EraToggleButton>
       </HeaderEraToggleWrapper>
       <HeaderPaginationWrapper>

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -9,7 +9,7 @@ import {
   getCurrentEraValidatorStatusStatus,
   getTotalEraValidators,
   getValidatorLoadingStatus,
-  getValidators,
+  getCurrentEraValidators,
   getValidatorsTableOptions,
   Loading,
   setValidatorTableOptions,
@@ -35,7 +35,7 @@ export const ValidatorTable: React.FC = () => {
 
   const dispatch = useAppDispatch();
 
-  const validators = useAppSelector(getValidators);
+  const validators = useAppSelector(getCurrentEraValidators);
   const validatorsLoadingStatus = useAppSelector(getValidatorLoadingStatus);
   const validatorsStatusLoadingStatus = useAppSelector(
     getCurrentEraValidatorStatusStatus,

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -17,6 +17,7 @@ import {
   updateValidatorSorting,
   useAppDispatch,
   useAppSelector,
+  getNextEraValidators,
 } from 'src/store';
 import { standardizeNumber, truncateHash } from 'src/utils';
 import { ApiData } from 'src/api/types';
@@ -30,12 +31,14 @@ import { NumberedPagination } from '../Pagination';
 
 export const ValidatorTable: React.FC = () => {
   const [isTableLoading, setIsTableLoading] = useState(false);
+  const [isCurrentEra, setIsCurrentEra] = useState(true);
 
   const { t } = useTranslation();
 
   const dispatch = useAppDispatch();
 
   const currentEraValidators = useAppSelector(getCurrentEraValidators);
+  const nextEraValidators = useAppSelector(getNextEraValidators);
   const validatorsLoadingStatus = useAppSelector(getValidatorLoadingStatus);
   const validatorsStatusLoadingStatus = useAppSelector(
     getCurrentEraValidatorStatusStatus,
@@ -162,11 +165,17 @@ export const ValidatorTable: React.FC = () => {
   const header = (
     <ValidatorTableHead>
       <HeaderEraToggleWrapper>
-        <EraToggleButton type="button" onClick={() => {}} selected>
-          Current
+        <EraToggleButton
+          type="button"
+          onClick={() => setIsCurrentEra(true)}
+          selected={isCurrentEra}>
+          Current Era
         </EraToggleButton>
-        <EraToggleButton type="button" onClick={() => {}}>
-          Next
+        <EraToggleButton
+          type="button"
+          selected={!isCurrentEra}
+          onClick={() => setIsCurrentEra(false)}>
+          Era
         </EraToggleButton>
       </HeaderEraToggleWrapper>
       <HeaderPaginationWrapper>
@@ -236,7 +245,7 @@ export const ValidatorTable: React.FC = () => {
     <Table<ApiData.ValidatorsInfo>
       header={header}
       columns={columns}
-      data={currentEraValidators}
+      data={isCurrentEra ? currentEraValidators : nextEraValidators}
       footer={footer}
       tableBodyLoading={isTableLoading || isPageLoading}
       currentPageSize={validatorsTableOptions.pagination.pageSize}
@@ -277,12 +286,14 @@ const HeaderEraToggleWrapper = styled.div`
   padding-bottom: 1rem;
 `;
 
-const EraToggleButton = styled.button<{ selected?: boolean }>`
+const EraToggleButton = styled.button<{ selected: boolean }>`
   border-style: none;
   background: ${({ selected, theme }) =>
     selected ? theme.button : theme.background.secondary};
   color: ${({ selected, theme }) =>
     selected ? theme.text.contrast : theme.text.primary};
+  width: ${pxToRem(208)};
+  height: ${pxToRem(38)};
 
   &:hover {
     cursor: pointer;

--- a/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
+++ b/app/src/components/tables/ValidatorTable/ValidatorTable.tsx
@@ -35,7 +35,7 @@ export const ValidatorTable: React.FC = () => {
 
   const dispatch = useAppDispatch();
 
-  const validators = useAppSelector(getCurrentEraValidators);
+  const currentEraValidators = useAppSelector(getCurrentEraValidators);
   const validatorsLoadingStatus = useAppSelector(getValidatorLoadingStatus);
   const validatorsStatusLoadingStatus = useAppSelector(
     getCurrentEraValidatorStatusStatus,
@@ -56,12 +56,12 @@ export const ValidatorTable: React.FC = () => {
       setIsTableLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [validators]);
+  }, [currentEraValidators]);
 
   const isPageLoading =
     validatorsLoadingStatus !== Loading.Complete ||
     validatorsStatusLoadingStatus !== Loading.Complete ||
-    !validators.length;
+    !currentEraValidators.length;
 
   const rowCountSelectOptions: SelectOptions[] | null = useMemo(
     () => [
@@ -161,17 +161,27 @@ export const ValidatorTable: React.FC = () => {
 
   const header = (
     <ValidatorTableHead>
-      <HeadValue>
-        {totalEraValidators} {t('total-rows')}
-      </HeadValue>
-      <NumberedPagination
-        tableOptions={validatorsTableOptions}
-        setTableOptions={setValidatorTableOptions}
-        rowCountSelectOptions={rowCountSelectOptions}
-        setIsTableLoading={setIsTableLoading}
-        totalPages={totalPages}
-        updatePageNum={updateValidatorPageNum}
-      />
+      <HeaderEraToggleWrapper>
+        <EraToggleButton type="button" onClick={() => {}} selected>
+          Current
+        </EraToggleButton>
+        <EraToggleButton type="button" onClick={() => {}}>
+          Next
+        </EraToggleButton>
+      </HeaderEraToggleWrapper>
+      <HeaderPaginationWrapper>
+        <HeadValue>
+          {totalEraValidators} {t('total-rows')}
+        </HeadValue>
+        <NumberedPagination
+          tableOptions={validatorsTableOptions}
+          setTableOptions={setValidatorTableOptions}
+          rowCountSelectOptions={rowCountSelectOptions}
+          setIsTableLoading={setIsTableLoading}
+          totalPages={totalPages}
+          updatePageNum={updateValidatorPageNum}
+        />
+      </HeaderPaginationWrapper>
     </ValidatorTableHead>
   );
 
@@ -226,7 +236,7 @@ export const ValidatorTable: React.FC = () => {
     <Table<ApiData.ValidatorsInfo>
       header={header}
       columns={columns}
-      data={validators}
+      data={currentEraValidators}
       footer={footer}
       tableBodyLoading={isTableLoading || isPageLoading}
       currentPageSize={validatorsTableOptions.pagination.pageSize}
@@ -245,15 +255,38 @@ export const ValidatorTable: React.FC = () => {
 
 const ValidatorTableHead = styled.div`
   display: flex;
+  flex-direction: column;
   min-width: ${pxToRem(825)};
   justify-content: space-between;
   align-items: center;
   color: ${props => props.theme.text.secondary};
-  height: ${pxToRem(42)};
 `;
 
 const HeadValue = styled.p`
   color: ${props => props.theme.text.secondary};
+`;
+
+const HeaderPaginationWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const HeaderEraToggleWrapper = styled.div`
+  padding-bottom: 1rem;
+`;
+
+const EraToggleButton = styled.button<{ selected?: boolean }>`
+  border-style: none;
+  background: ${({ selected, theme }) =>
+    selected ? theme.button : theme.background.secondary};
+  color: ${({ selected, theme }) =>
+    selected ? theme.text.contrast : theme.text.primary};
+
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 const CSPRText = styled.span`

--- a/app/src/store/selectors/validator-selectors.ts
+++ b/app/src/store/selectors/validator-selectors.ts
@@ -1,7 +1,11 @@
 import { RootState } from '../store';
 
-export const getValidators = (state: RootState) => {
-  return state.validator.validators;
+export const getCurrentEraValidators = (state: RootState) => {
+  return state.validator.currentEraValidators;
+};
+
+export const getNextEraValidators = (state: RootState) => {
+  return state.validator.nextEraValidators;
 };
 
 export const getValidatorLoadingStatus = (state: RootState) => {

--- a/app/src/store/slices/validator-slice.ts
+++ b/app/src/store/slices/validator-slice.ts
@@ -17,7 +17,8 @@ import { VALIDATOR_TABLE_OPTIONS } from '../constants';
 
 export interface ValidatorState {
   status: Loading;
-  validators: ApiData.ValidatorsInfo[];
+  currentEraValidators: ApiData.ValidatorsInfo[];
+  nextEraValidators: ApiData.ValidatorsInfo[];
   currentEraValidatorStatus: ApiData.CurrentEraValidatorStatus | null;
   currentEraValidatorStatusLoadingStatus: Loading;
   tableOptions: TableOptions;
@@ -36,7 +37,8 @@ const defaultTableOptions: TableOptions = {
 
 const initialState: ValidatorState = {
   status: Loading.Idle,
-  validators: [],
+  currentEraValidators: [],
+  nextEraValidators: [],
   currentEraValidatorStatus: null,
   currentEraValidatorStatusLoadingStatus: Loading.Idle,
   tableOptions: defaultTableOptions,
@@ -119,9 +121,18 @@ export const validatorSlice = createSlice({
       })
       .addCase(
         fetchValidators.fulfilled,
-        (state, { payload }: PayloadAction<ApiData.ValidatorsInfo[]>) => {
+        (
+          state,
+          {
+            payload,
+          }: PayloadAction<{
+            currentEraValidators: ApiData.ValidatorsInfo[];
+            nextEraValidators: ApiData.ValidatorsInfo[];
+          }>,
+        ) => {
           state.status = Loading.Complete;
-          state.validators = payload;
+          state.currentEraValidators = payload.currentEraValidators;
+          state.nextEraValidators = payload.nextEraValidators;
         },
       )
       .addCase(fetchValidators.rejected, state => {


### PR DESCRIPTION
### 🔥 Summary
https://github.com/casper-network/casper-blockexplorer-frontend/issues/349:
<img width="1229" alt="Screenshot 2023-06-01 at 9 09 08 AM" src="https://github.com/casper-network/casper-blockexplorer-frontend/assets/124628688/9866cbb8-5e3e-47ad-a1de-158edf7d2928">

### 📹 Video

### 😤 Problem / Goals
-

### 🤓 Solution
-

### 🗒️ Additional Notes
- Corresponding backend PR: https://github.com/casper-network/casper-blockexplorer-middleware/pull/84
