### PR TITLE
Fix Block Details E2E Test

### DIFF
--- a/app/src/components/cards/BlockDetailsCard/BlockDetailsCard.tsx
+++ b/app/src/components/cards/BlockDetailsCard/BlockDetailsCard.tsx
@@ -43,7 +43,10 @@ export const BlockDetailsCard: React.FC<BlockDetailsCardProps> = ({
     <div data-testid="block-details-card">
       <PageHeading>
         <HashWrapper>
-          <HashHeading type="h2" isTruncated={isTruncated}>
+          <HashHeading
+            type="h2"
+            isTruncated={isTruncated}
+            data-cy="hash-heading">
             {withSkeletonLoading(
               <Hash
                 hash={block?.hash ?? hashPlaceholder}
@@ -69,7 +72,10 @@ export const BlockDetailsCard: React.FC<BlockDetailsCardProps> = ({
           <DetailDataRowWrapper>
             <li>
               <DetailDataLabel>{t('block-height')}</DetailDataLabel>
-              <DetailDataValue data-testid="block-height" isLargeText>
+              <DetailDataValue
+                data-testid="block-height"
+                data-cy="block-height"
+                isLargeText>
                 {withSkeletonLoading(block?.header.height, isLoading, {
                   width: 100,
                 })}
@@ -237,6 +243,8 @@ export const BlockDetailsCard: React.FC<BlockDetailsCardProps> = ({
   );
 };
 
+const { breakpoints } = defaultTheme.typography;
+
 const HashWrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -259,8 +267,7 @@ const DetailDataRowWrapper = styled.ul`
   display: flex;
   flex-direction: column;
 
-  @media only screen and (min-width: ${defaultTheme.typography.breakpoints
-      .lg}) {
+  @media only screen and (min-width: ${breakpoints.lg}) {
     flex-direction: row;
     flex-wrap: wrap;
     gap: ${pxToRem(96)};
@@ -268,8 +275,7 @@ const DetailDataRowWrapper = styled.ul`
 `;
 
 const PageHeading = styled.div`
-  @media only screen and (min-width: ${defaultTheme.typography.breakpoints
-      .lg}) {
+  @media only screen and (min-width: ${breakpoints.lg}) {
     margin-bottom: 2rem;
   }
 `;

--- a/app/src/components/cards/BlockDetailsCard/MobileBlockDetailsCard.tsx
+++ b/app/src/components/cards/BlockDetailsCard/MobileBlockDetailsCard.tsx
@@ -43,7 +43,7 @@ export const MobileBlockDetailsCard: React.FC<MobileBlockDetailsCardProps> = ({
           <DetailDataRowWrapper>
             <li>
               <DetailDataLabel>{t('block-height')}</DetailDataLabel>
-              <DetailDataValue>
+              <DetailDataValue data-cy="block-height">
                 {withSkeletonLoading(block?.header.height, isLoading, {
                   width: 100,
                 })}

--- a/test/cypress/e2e/block.cy.ts
+++ b/test/cypress/e2e/block.cy.ts
@@ -1,42 +1,12 @@
-interface RpcRequestBody {
-  id: string;
-  jsonrpc: string;
-  method: string;
-  params?: any;
-}
-interface RpcResponseBody {
-  id: string;
-  jsonrpc: string;
-  result: any;
-}
-
 describe('Block Page', () => {
-  const middlewareUrl = Cypress.env('MIDDLEWARE_URL') as string;
-
-  it('can visit at /block/:blockHeight?type=height', () => {
+  it('can visit at /block/:blockHeight', () => {
     const blockHeight = 1;
-    cy.intercept('POST', `${middlewareUrl}/rpc`, req => {
-      const body = req.body as RpcRequestBody;
-      if (
-        body.method === 'chain_get_block' &&
-        body.params &&
-        body.params.block_identifier
-      ) {
-        req.alias = 'blockFetch';
-      }
-    });
 
     cy.visit(`/block/${blockHeight}?type=height`);
 
-    cy.wait('@blockFetch').its('response.statusCode').should('equal', 200);
+    cy.contains('Block Height').should('be.visible');
 
-    cy.wait('@blockFetch').then(interception => {
-      const { result } = interception.response.body as RpcResponseBody;
-      const blockHash = result.block.hash as string;
-      const truncatedBlockHash = `${blockHash.slice(0, 5)}...${blockHash.slice(
-        -5,
-      )}`;
-      cy.contains(truncatedBlockHash).should('be.visible');
-    });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    cy.getByData('block-height').should('be.visible').contains(blockHeight);
   });
 });


### PR DESCRIPTION
### 🔥 Summary
Closes #309 

Cypress E2E test for the block details page broke after integrating sidecar.   This was due to the change in how we were requesting for block information -- before we were using the SDK which used an odd request pattern that was easy to intercept.

This ticket is only to fix the existing test.

### 😤 Problem / Goals
- Block details E2E test is failing

### 🤓 Solution
- Remove request interception and re-write basic test
