### PR TITLE
Fix Cypress E2E Blocks Page Test

### DIFF
--- a/app/src/components/layout/Header/Header.styled.ts
+++ b/app/src/components/layout/Header/Header.styled.ts
@@ -58,7 +58,7 @@ export const HeroHeading = styled(Heading)`
   }
 `;
 
-export const PageTableHeader = styled.p`
+export const PageTableHeader = styled.h1`
   font-size: clamp(2.7rem, 5.5vw, 3.75rem);
   margin: 1.5rem 0 2.5rem 0;
   color: ${props => props.theme.text.primary};

--- a/app/src/components/tables/BlockTable/BlocksTable.tsx
+++ b/app/src/components/tables/BlockTable/BlocksTable.tsx
@@ -199,7 +199,6 @@ export const BlocksTable: React.FC<BlocksTableProps> = ({
           </div>
         ),
         enableSorting: false,
-        // isVisible: showValidators,
         minSize: 230,
       },
     ],

--- a/test/cypress/e2e/blocks.cy.ts
+++ b/test/cypress/e2e/blocks.cy.ts
@@ -1,10 +1,9 @@
 describe('Blocks Page', () => {
   beforeEach(() => cy.visit('/blocks'));
 
-  it('should title visible', () => {
+  it('should display title', () => {
     const blocksPageTitle = 'Blocks';
-    cy.get('h2').contains(blocksPageTitle).should('be.visible');
-  });
 
-  it('should load more blocks');
+    cy.get('h1').contains(blocksPageTitle).should('be.visible');
+  });
 });

--- a/test/cypress/e2e/blocks.cy.ts
+++ b/test/cypress/e2e/blocks.cy.ts
@@ -5,5 +5,9 @@ describe('Blocks Page', () => {
     const blocksPageTitle = 'Blocks';
 
     cy.get('h1').contains(blocksPageTitle).should('be.visible');
+
+    const blocksTableHeading = 'Latest Blocks';
+
+    cy.contains(blocksTableHeading).should('be.visible');
   });
 });


### PR DESCRIPTION
### 🔥 Summary
Closes #310 

The Blocks page Cypress E2E test is failing.  This is due to an incorrect `cy.get` query.  This test is very basic and we should consider going back and writing more useful tests

### 😤 Problem / Goals
- Blocks page Cypress test is failing

### 🤓 Solution
- Update page header to use an `h1` tag
- Update test `.get` query to search for an h1

### 🗒️ Additional Notes
- This PR is opened against the previous Cypress test fix branch.  I will be updating this PR to point to dev once #363 has been merged