### PR TITLE
feat-381: update sidecar deploy types to match API

### DIFF
--- a/app/src/api/api.ts
+++ b/app/src/api/api.ts
@@ -7,7 +7,7 @@ import { SortDirection } from '@tanstack/react-table';
 import { loadConfig } from 'src/utils';
 import { DEFAULT_PAGESIZE } from 'src/constants';
 import { createBaseApi } from './base-api';
-import { ApiData, Deploy } from './types';
+import { ApiData } from './types';
 import { isValidPublicKey } from './utils';
 
 const { webServerUrl } = loadConfig();
@@ -208,8 +208,7 @@ const createApi = (baseUrl: string) => {
         return data;
       },
       async getDeploys() {
-        // TODO: need to update this type to match sidecar deploys type - #381
-        type Response = AxiosResponse<Deploy[]>;
+        type Response = AxiosResponse<ApiData.SidecarDeploy[]>;
 
         const response = await middlewareApi.get<Response>('/deploys');
 

--- a/app/src/api/types.ts
+++ b/app/src/api/types.ts
@@ -125,6 +125,50 @@ export namespace ApiData {
     status: DeployStatus;
     rawDeploy: string;
   }
+
+  export interface SidecarDeploy {
+    block_timestamp?: string;
+    deploy_hash: string;
+    deploy_accepted: {
+      hash: string;
+      header: {
+        account: string;
+        timestamp: string;
+        ttl: string;
+        gas_price: number;
+        body_hash: string;
+        dependencies: any[];
+        chain_name: string;
+      };
+      payment: {
+        ModuleBytes?: { args: any[]; module_bytes?: string };
+        Transfer?: { args: any[] };
+      };
+      session: {
+        ModuleBytes?: {
+          args: any[];
+          module_bytes?: string;
+          entry_point?: string;
+          hash?: string;
+        };
+        Transfer?: { args: any[] };
+      };
+      approvals: {
+        signature: string;
+        signer: string;
+      }[];
+    };
+    deploy_processed: {
+      deploy_hash: string;
+      account: string;
+      timestamp: string;
+      ttl: string;
+      dependencies: any[];
+      block_hash: string;
+      execution_result: { Failure?: object; Success?: object };
+    } | null;
+    deploy_expired: boolean;
+  }
 }
 
 export type Account = {

--- a/app/src/store/slices/deploy-slice.ts
+++ b/app/src/store/slices/deploy-slice.ts
@@ -1,13 +1,14 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import { AxiosError } from 'axios';
 import { formatDate, formatTimeAgo } from 'src/utils';
+import { ApiData } from 'src/api/types';
 import { Deploy, middlewareServiceApi } from '../../api';
 import { Loading } from '../loading.type';
 
 export interface DeployState {
   status: Loading;
   deploy: Deploy | null;
-  deploys: Deploy[];
+  deploys: ApiData.SidecarDeploy[];
   deploysLoadingStatus: Loading;
   errorMessage: string | null;
 }
@@ -80,7 +81,7 @@ export const deploySlice = createSlice({
       })
       .addCase(
         fetchDeploys.fulfilled,
-        (state, { payload }: PayloadAction<Deploy[]>) => {
+        (state, { payload }: PayloadAction<ApiData.SidecarDeploy[]>) => {
           state.deploysLoadingStatus = Loading.Complete;
           state.deploys = payload;
         },


### PR DESCRIPTION
### 🔥 Summary
https://github.com/casper-network/casper-blockexplorer-frontend/issues/381

### 📹 Video

### 😤 Problem / Goals
-

### 🤓 Solution
-

### 🗒️ Additional Notes
-
