### PR TITLE
feat-396: add sorting to deploys table for block timestamp

### DIFF
--- a/app/src/api/api.ts
+++ b/app/src/api/api.ts
@@ -224,6 +224,11 @@ const createApi = (baseUrl: string) => {
           params: {
             ...tableParams,
             count: tableParams?.count ?? DEFAULT_PAGESIZE,
+            // TODO: temporary until sidecar /deploys endpoint is fully released - middleware #88
+            sortBy:
+              tableParams.sortBy === 'timestamp'
+                ? 'block_timestamp'
+                : tableParams.sortBy,
           },
         });
 

--- a/app/src/components/tables/DeploysTable/DeploysTable.tsx
+++ b/app/src/components/tables/DeploysTable/DeploysTable.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { ColumnDef } from '@tanstack/react-table';
+import { ColumnDef, OnChangeFn, SortingState } from '@tanstack/react-table';
 import { SelectOptions, defaultTheme, pxToRem } from 'casper-ui-kit';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,6 +17,7 @@ import {
   getTotalDeploys,
   setDeploysTableOptions,
   updateDeploysPageNum,
+  updateDeploysSorting,
   useAppDispatch,
   useAppSelector,
 } from 'src/store';
@@ -159,7 +160,6 @@ export const DeploysTable: React.FC = () => {
         cell: ({ getValue }) => (
           <Age>{formatTimeAgo(new Date(getValue<number>()))}</Age>
         ),
-        enableSorting: false,
       },
       {
         header: `${t('contract')}`,
@@ -195,6 +195,31 @@ export const DeploysTable: React.FC = () => {
     [t],
   );
 
+  const onSortingChange: OnChangeFn<SortingState> = updaterOrValue => {
+    setIsTableLoading(true);
+
+    if (updaterOrValue instanceof Function) {
+      const [updatedVal] = updaterOrValue([
+        {
+          id: deploysTableOptions.sorting.sortBy,
+          desc: deploysTableOptions.sorting.order === 'desc',
+        },
+      ]);
+
+      let order: 'desc' | 'asc' = 'desc';
+      if (deploysTableOptions.sorting.sortBy === updatedVal.id) {
+        order = updatedVal.desc ? 'desc' : 'asc';
+      }
+
+      dispatch(
+        updateDeploysSorting({
+          sortBy: updatedVal.id,
+          order,
+        }),
+      );
+    }
+  };
+
   return (
     <Table<ApiData.ProcessedSidecarDeploy>
       header={header}
@@ -216,6 +241,13 @@ export const DeploysTable: React.FC = () => {
         amountMotes: '505124902204510',
         costMotes: '100000000',
       }}
+      sorting={[
+        {
+          id: deploysTableOptions.sorting.sortBy,
+          desc: deploysTableOptions.sorting.order === 'desc',
+        },
+      ]}
+      onSortingChange={onSortingChange}
     />
   );
 };

--- a/app/src/store/slices/deploy-slice.ts
+++ b/app/src/store/slices/deploy-slice.ts
@@ -23,7 +23,7 @@ const defaultTableOptions: TableOptions = {
     pageNum: 1,
   },
   sorting: {
-    sortBy: 'block_timestamp',
+    sortBy: 'timestamp',
     order: 'desc',
   },
 };
@@ -93,6 +93,12 @@ export const deploySlice = createSlice({
     updateDeploysPageNum: (state, action: PayloadAction<number>) => {
       state.tableOptions.pagination.pageNum += action.payload;
     },
+    updateDeploysSorting: (
+      state,
+      action: PayloadAction<DeployState['tableOptions']['sorting']>,
+    ) => {
+      state.tableOptions.sorting = action.payload;
+    },
   },
   extraReducers(builder) {
     builder
@@ -137,5 +143,8 @@ export const deploySlice = createSlice({
   },
 });
 
-export const { setDeploysTableOptions, updateDeploysPageNum } =
-  deploySlice.actions;
+export const {
+  setDeploysTableOptions,
+  updateDeploysPageNum,
+  updateDeploysSorting,
+} = deploySlice.actions;


### PR DESCRIPTION
### 🔥 Summary
https://github.com/casper-network/casper-blockexplorer-frontend/issues/396

### 📹 Video

### 😤 Problem / Goals
-

### 🤓 Solution
-

### 🗒️ Additional Notes
-
