### PR TITLE
chore: ignore semver moderate vulnerability

### DIFF
--- a/app/.nsprc
+++ b/app/.nsprc
@@ -3,5 +3,10 @@
     "active": false,
     "notes": "Ignored until css-minimizer-webpack-plugin, postcss-loader, & fork-ts-checker-webpack-plugin add a fix.",
     "expiry": "1 May 2023 9:00 am"
+  },
+  "1092310": {
+    "active": true,
+    "notes": "Ignored until @babel/core fixes semver minimum version to 7.5.2. See https://github.com/babel/babel/blob/04f063ef008fba36a37f91d31d929476ac5e0937/packages/babel-core/package.json#L63",
+    "expiry": "1 July 2023 9:00 am"
   }
 }


### PR DESCRIPTION
### 🔥 Summary
See [this PR](https://github.com/casper-network/casper-blockexplorer-middleware/pull/112) for context.

