### PR TITLE
Feat#418/add optional loading prop

### DIFF
--- a/app/.nsprc
+++ b/app/.nsprc
@@ -2,7 +2,7 @@
   "1092310": {
     "active": true,
     "notes": "Ignored until @babel/core fixes semver minimum version to 7.5.2. See https://github.com/babel/babel/blob/04f063ef008fba36a37f91d31d929476ac5e0937/packages/babel-core/package.json#L63",
-    "expiry": "1 July 2023 9:00 am"
+    "expiry": "1 August 2023 9:00am"
   },
   "1092330": {
     "active": true,

--- a/app/src/components/layout/PageWrapper/PageWrapper.test.tsx
+++ b/app/src/components/layout/PageWrapper/PageWrapper.test.tsx
@@ -15,9 +15,7 @@ describe(PageWrapper, () => {
 
   it('should render error content when error occurred', () => {
     const { getByTestId } = render(
-      <PageWrapper isLoading={false} error={{ message: 'error message' }}>
-        Content
-      </PageWrapper>,
+      <PageWrapper error={{ message: 'error message' }}>Content</PageWrapper>,
     );
 
     const errorContent = getByTestId('error-content');

--- a/app/src/components/layout/PageWrapper/PageWrapper.test.tsx
+++ b/app/src/components/layout/PageWrapper/PageWrapper.test.tsx
@@ -26,7 +26,7 @@ describe(PageWrapper, () => {
 
   it('should render children when done loading & no error', () => {
     const { getByTestId } = render(
-      <PageWrapper isLoading={false}>
+      <PageWrapper>
         <p data-testid="children-content">Content</p>
       </PageWrapper>,
     );

--- a/app/src/components/layout/PageWrapper/PageWrapper.tsx
+++ b/app/src/components/layout/PageWrapper/PageWrapper.tsx
@@ -10,7 +10,7 @@ export interface PageError {
 }
 
 interface PageWrapperProps {
-  readonly isLoading: boolean;
+  readonly isLoading?: boolean;
   readonly error?: PageError;
   readonly children: React.ReactNode;
 }

--- a/app/src/pages/Account.tsx
+++ b/app/src/pages/Account.tsx
@@ -51,7 +51,7 @@ export const AccountPage: React.FC = () => {
   const pageTitle = `${t('account-details')}`;
 
   return (
-    <PageWrapper error={error} isLoading={false}>
+    <PageWrapper error={error}>
       <PageHead pageTitle={pageTitle} />
       <AccountDetailsCard
         isBalanceLoading={balanceLoadingStatus !== Loading.Complete}

--- a/app/src/pages/Block.tsx
+++ b/app/src/pages/Block.tsx
@@ -45,7 +45,7 @@ export const BlockPage: React.FC = () => {
   const pageTitle = `${t('block-details')}`;
 
   return (
-    <PageWrapper error={error} isLoading={false}>
+    <PageWrapper error={error}>
       <PageHead pageTitle={pageTitle} />
       {isMobile ? (
         <MobileBlockDetailsCard

--- a/app/src/pages/Blocks.tsx
+++ b/app/src/pages/Blocks.tsx
@@ -9,7 +9,7 @@ export const Blocks: React.FC = () => {
   const pageTitle = `${t('blocks')}`;
 
   return (
-    <PageWrapper isLoading={false}>
+    <PageWrapper>
       <PageHead pageTitle={pageTitle} />
       <PageTableHeader>{t('blocks')}</PageTableHeader>
       <BlocksTable />

--- a/app/src/pages/Deploy.tsx
+++ b/app/src/pages/Deploy.tsx
@@ -41,7 +41,7 @@ export const DeployPage: React.FC = () => {
   }, [deployErrorMessage]);
 
   return (
-    <PageWrapper error={error} isLoading={false}>
+    <PageWrapper error={error}>
       <PageHead pageTitle={pageTitle} />
       <Grid gap="2.5rem">
         <DeployDetailsCard deploy={deploy} isLoading={isLoading} />

--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -49,7 +49,7 @@ export const Home: React.FC = () => {
   const { isFirstVisit } = useAppSelector(state => state.app);
 
   return (
-    <PageWrapper isLoading={false}>
+    <PageWrapper>
       <HomeContentContainer
         data-cy="home-content-container"
         isFirstVisit={isFirstVisit}>

--- a/app/src/pages/Peers.tsx
+++ b/app/src/pages/Peers.tsx
@@ -9,7 +9,7 @@ export const Peers: React.FC = () => {
   const pageTitle = `${t('peers')}`;
 
   return (
-    <PageWrapper isLoading={false}>
+    <PageWrapper>
       <PageHead pageTitle={pageTitle} />
       <PageTableHeader>{t('connected-peers')}</PageTableHeader>
       <PeersTable />

--- a/app/src/pages/Validators.tsx
+++ b/app/src/pages/Validators.tsx
@@ -9,7 +9,7 @@ export const Validators: React.FC = () => {
   const pageTitle = `${t('validators')}`;
 
   return (
-    <PageWrapper isLoading={false}>
+    <PageWrapper>
       <PageHead pageTitle={pageTitle} />
       <PageTableHeader>{t('validators')}</PageTableHeader>
       <ValidatorTable />


### PR DESCRIPTION
🔥 Summary
Removes all instances of `isLoading={false}` and makes `isLoading` prop optional. https://github.com/casper-network/casper-blockexplorer-frontend/issues/418
