### PR TITLE
Feat#413: add peers table tests

### DIFF
--- a/app/.nsprc
+++ b/app/.nsprc
@@ -1,12 +1,17 @@
 {
-  "1092310": {
+  "1092413": {
     "active": true,
-    "notes": "Ignored until @babel/core fixes semver minimum version to 7.5.2. See https://github.com/babel/babel/blob/04f063ef008fba36a37f91d31d929476ac5e0937/packages/babel-core/package.json#L63",
-    "expiry": "1 August 2023 9:00am"
+    "notes": "Another semver id: Ignored until @babel/core fixes semver minimum version to 7.5.2. See https://github.com/babel/babel/blob/04f063ef008fba36a37f91d31d929476ac5e0937/packages/babel-core/package.json#L63",
+    "expiry": "1 August 2023 9:00 am"
   },
   "1092330": {
     "active": true,
     "notes": "Ignored until either word-wrap publishes a new release or whichever package uses word-wrap finds a work around",
+    "expiry": "1 August 2023 9:00 am"
+  },
+  "1092448": {
+    "active": true,
+    "notes": "Ignored until jest-environment-jsdom upgrades jsdom and jsdom upgrades tough-cookie",
     "expiry": "1 August 2023 9:00 am"
   }
 }

--- a/app/.nsprc
+++ b/app/.nsprc
@@ -24,7 +24,8 @@
     "notes": "Ignored until jest-environment-jsdom upgrades jsdom and jsdom upgrades tough-cookie",
     "expiry": "1 August 2023 9:00 am"
   },
-  "1092470": true,
+  "1092470": {
+    "active": true,
     "notes": "Ignored until jest-environment-jsdom upgrades jsdom and jsdom upgrades tough-cookie",
     "expiry": "1 August 2023 9:00 am"
   }

--- a/app/.nsprc
+++ b/app/.nsprc
@@ -4,6 +4,16 @@
     "notes": "Another semver id: Ignored until @babel/core fixes semver minimum version to 7.5.2. See https://github.com/babel/babel/blob/04f063ef008fba36a37f91d31d929476ac5e0937/packages/babel-core/package.json#L63",
     "expiry": "1 August 2023 9:00 am"
   },
+  "1092460": {
+    "active": true,
+    "notes": "Another semver id: Ignored until @babel/core fixes semver minimum version to 7.5.2. See https://github.com/babel/babel/blob/04f063ef008fba36a37f91d31d929476ac5e0937/packages/babel-core/package.json#L63",
+    "expiry": "1 August 2023 9:00 am"
+  },
+  "1092461": {
+    "active": true,
+    "notes": "Another semver id: Ignored until @babel/core fixes semver minimum version to 7.5.2. See https://github.com/babel/babel/blob/04f063ef008fba36a37f91d31d929476ac5e0937/packages/babel-core/package.json#L63",
+    "expiry": "1 August 2023 9:00 am"
+  },
   "1092330": {
     "active": true,
     "notes": "Ignored until either word-wrap publishes a new release or whichever package uses word-wrap finds a work around",

--- a/app/.nsprc
+++ b/app/.nsprc
@@ -23,5 +23,9 @@
     "active": true,
     "notes": "Ignored until jest-environment-jsdom upgrades jsdom and jsdom upgrades tough-cookie",
     "expiry": "1 August 2023 9:00 am"
+  },
+  "1092470": true,
+    "notes": "Ignored until jest-environment-jsdom upgrades jsdom and jsdom upgrades tough-cookie",
+    "expiry": "1 August 2023 9:00 am"
   }
 }

--- a/app/.nsprc
+++ b/app/.nsprc
@@ -19,11 +19,6 @@
     "notes": "Ignored until either word-wrap publishes a new release or whichever package uses word-wrap finds a work around",
     "expiry": "1 August 2023 9:00 am"
   },
-  "1092448": {
-    "active": true,
-    "notes": "Ignored until jest-environment-jsdom upgrades jsdom and jsdom upgrades tough-cookie",
-    "expiry": "1 August 2023 9:00 am"
-  },
   "1092470": {
     "active": true,
     "notes": "Ignored until jest-environment-jsdom upgrades jsdom and jsdom upgrades tough-cookie",

--- a/app/src/components/tables/PeersTable/PeersTable.test.tsx
+++ b/app/src/components/tables/PeersTable/PeersTable.test.tsx
@@ -14,7 +14,7 @@ const mockPeers = getMockPeers();
 const mockPeersTableHeader = getMockPeersTableHeader();
 const mockPeersTableFooter = getMockPeersTableFooter();
 const totalPages = Math.ceil(
-  mockPeers.totalPeers / mockPeersTableOptions.pagination.pageSize,
+  mockPeers.paginatedResult.length / mockPeersTableOptions.pagination.pageSize,
 );
 
 describe('PeersTable', () => {
@@ -27,7 +27,8 @@ describe('PeersTable', () => {
         footer={mockPeersTableFooter}
         currentPageSize={mockPeersTableOptions.pagination.pageSize}
         placeholderData={{}}
-        isLastPage={totalPages === mockPeersTableOptions.pagination.pageSize}
+        // isLastPage={totalPages === mockPeersTableOptions.pagination.pageSize}
+        isLastPage
       />,
     ),
   );
@@ -47,13 +48,15 @@ describe('PeersTable', () => {
     expect(totalPeers).toHaveTextContent(mockPeers.totalPeers.toString());
   });
 
-  //   it('should render a truncated Public Key', () => {
+  it('should render a Node Id', () => {
+    const nodeId = screen.getAllByTestId('node-id');
+    expect(nodeId[0]).toHaveTextContent(mockPeers.paginatedResult[0].nodeId);
+  });
 
-  //   });
-
-  //   it('should render a Fee', () => {
-
-  //   });
+  it('should render an Address', () => {
+    const address = screen.getAllByTestId('address');
+    expect(address[0]).toHaveTextContent(mockPeers.paginatedResult[0].address);
+  });
 
   it('should render a loading PeersTable', () => {
     render(
@@ -69,6 +72,6 @@ describe('PeersTable', () => {
       />,
     );
     const skeletonLoader = screen.getAllByTestId('skeleton-loader');
-    expect(skeletonLoader).toHaveLength(20);
+    expect(skeletonLoader).toHaveLength(2);
   });
 });

--- a/app/src/components/tables/PeersTable/PeersTable.test.tsx
+++ b/app/src/components/tables/PeersTable/PeersTable.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { Table } from 'src/components';
+import {
+  getMockPeers,
+  mockPeersTableColumns,
+  getMockPeersTableHeader,
+  getMockPeersTableFooter,
+  mockPeersTableOptions,
+} from '../../../mocks/mock-peers-table';
+import { render } from '../../../test-utils';
+
+const mockPeers = getMockPeers();
+const mockPeersTableHeader = getMockPeersTableHeader();
+const mockPeersTableFooter = getMockPeersTableFooter();
+const totalPages = Math.ceil(
+  mockPeers.totalPeers / mockPeersTableOptions.pagination.pageSize,
+);
+
+describe('PeersTable', () => {
+  beforeEach(() =>
+    render(
+      <Table
+        header={mockPeersTableHeader}
+        columns={mockPeersTableColumns}
+        data={mockPeers.paginatedResult}
+        footer={mockPeersTableFooter}
+        currentPageSize={mockPeersTableOptions.pagination.pageSize}
+        placeholderData={{}}
+        isLastPage={totalPages === mockPeersTableOptions.pagination.pageSize}
+      />,
+    ),
+  );
+
+  it('should render Peers Table', () => {
+    const peersTableHeader = screen.getByTestId('peers-table-header');
+    const peersBaseTable = screen.getByTestId('base-table');
+    const peersTableFooter = screen.getByTestId('peers-table-footer');
+
+    expect(peersTableHeader).toBeInTheDocument();
+    expect(peersBaseTable).toBeInTheDocument();
+    expect(peersTableFooter).toBeInTheDocument();
+  });
+
+  it('should render Total Peers', () => {
+    const totalPeers = screen.getByTestId('total-peers');
+    expect(totalPeers).toHaveTextContent(mockPeers.totalPeers.toString());
+  });
+
+  //   it('should render a truncated Public Key', () => {
+
+  //   });
+
+  //   it('should render a Fee', () => {
+
+  //   });
+
+  it('should render a loading PeersTable', () => {
+    render(
+      <Table
+        header={mockPeersTableHeader}
+        columns={mockPeersTableColumns}
+        data={mockPeers.paginatedResult}
+        footer={mockPeersTableFooter}
+        tableBodyLoading
+        currentPageSize={mockPeersTableOptions.pagination.pageSize}
+        placeholderData={{}}
+        isLastPage={totalPages === mockPeersTableOptions.pagination.pageSize}
+      />,
+    );
+    const skeletonLoader = screen.getAllByTestId('skeleton-loader');
+    expect(skeletonLoader).toHaveLength(20);
+  });
+});

--- a/app/src/components/tables/PeersTable/PeersTable.test.tsx
+++ b/app/src/components/tables/PeersTable/PeersTable.test.tsx
@@ -16,6 +16,7 @@ const mockPeersTableFooter = getMockPeersTableFooter();
 const totalPages = Math.ceil(
   mockPeers.paginatedResult.length / mockPeersTableOptions.pagination.pageSize,
 );
+const totalColumns = mockPeersTableColumns.length;
 
 describe('PeersTable', () => {
   beforeEach(() =>
@@ -27,8 +28,7 @@ describe('PeersTable', () => {
         footer={mockPeersTableFooter}
         currentPageSize={mockPeersTableOptions.pagination.pageSize}
         placeholderData={{}}
-        // isLastPage={totalPages === mockPeersTableOptions.pagination.pageSize}
-        isLastPage
+        isLastPage={totalPages === mockPeersTableOptions.pagination.pageSize}
       />,
     ),
   );
@@ -72,6 +72,8 @@ describe('PeersTable', () => {
       />,
     );
     const skeletonLoader = screen.getAllByTestId('skeleton-loader');
-    expect(skeletonLoader).toHaveLength(2);
+    expect(skeletonLoader).toHaveLength(
+      mockPeers.paginatedResult.length * totalColumns,
+    );
   });
 });

--- a/app/src/components/tables/ValidatorTable/index.ts
+++ b/app/src/components/tables/ValidatorTable/index.ts
@@ -1,1 +1,0 @@
-export { ValidatorTable } from './ValidatorTable';

--- a/app/src/components/tables/ValidatorsTable/ValidatorsTable.test.tsx
+++ b/app/src/components/tables/ValidatorsTable/ValidatorsTable.test.tsx
@@ -13,7 +13,7 @@ import { standardizeNumber, truncateHash } from 'src/utils';
 import { standardizePercentage } from 'src/utils/standardize-percentage';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../../test-utils';
-import { EraToggleButton } from './ValidatorTable';
+import { EraToggleButton } from './ValidatorsTable';
 
 const mockCurrentEraValidators = getMockCurrentEraValidators();
 const mockNextEraValidators = getMockNextEraValidators();

--- a/app/src/components/tables/ValidatorsTable/ValidatorsTable.test.tsx
+++ b/app/src/components/tables/ValidatorsTable/ValidatorsTable.test.tsx
@@ -3,11 +3,14 @@ import { screen } from '@testing-library/react';
 import { Table } from 'src/components';
 import {
   getMockCurrentEraValidators,
-  getMockValidatorsTableFooter,
+  getMockCurrentEraValidatorsTableHeader,
   mockValidatorsTableColumns,
-  mockValidatorsTableOptions,
+  getMockCurrentEraValidatorsTableFooter,
+  mockCurrentEraValidatorsTableOptions,
   getMockNextEraValidators,
-  getMockValidatorsTableHeader,
+  getMockNextEraValidatorsTableFooter,
+  getMockNextEraValidatorsTableHeader,
+  mockNextEraValidatorsTableOptions,
 } from 'src/mocks/mock-validator-table';
 import { standardizeNumber, truncateHash } from 'src/utils';
 import { standardizePercentage } from 'src/utils/standardize-percentage';
@@ -16,26 +19,40 @@ import { render } from '../../../test-utils';
 import { EraToggleButton } from './ValidatorsTable';
 
 const mockCurrentEraValidators = getMockCurrentEraValidators();
-const mockNextEraValidators = getMockNextEraValidators();
-const mockValidatorsTableHeader = getMockValidatorsTableHeader();
-const mockValidatorsTableFooter = getMockValidatorsTableFooter();
-const totalPages = Math.ceil(
-  mockCurrentEraValidators.status.validatorsCount /
-    mockValidatorsTableOptions.pagination.pageSize,
+const mockCurrentEraValidatorsTableHeader =
+  getMockCurrentEraValidatorsTableHeader();
+const mockCurrentEraValidatorsTableFooter =
+  getMockCurrentEraValidatorsTableFooter();
+const currentEraTotalPages = Math.ceil(
+  mockCurrentEraValidators.validators.length /
+    mockCurrentEraValidatorsTableOptions.pagination.pageSize,
 );
+
+const mockNextEraValidators = getMockNextEraValidators();
+const mockNextEraValidatorsTableHeader = getMockNextEraValidatorsTableHeader();
+const mockNextEraValidatorsTableFooter = getMockNextEraValidatorsTableFooter();
+const nexEraTotalPages = Math.ceil(
+  mockNextEraValidators.nextEraValidators.length /
+    mockNextEraValidatorsTableOptions.pagination.pageSize,
+);
+
+const totalColumns = mockValidatorsTableColumns.length;
 
 describe('ValidatorsTable', () => {
   beforeEach(() =>
     render(
       <Table
-        header={mockValidatorsTableHeader}
+        header={mockCurrentEraValidatorsTableHeader}
         columns={mockValidatorsTableColumns}
         data={mockCurrentEraValidators.validators}
-        footer={mockValidatorsTableFooter}
-        currentPageSize={mockValidatorsTableOptions.pagination.pageSize}
+        footer={mockCurrentEraValidatorsTableFooter}
+        currentPageSize={
+          mockCurrentEraValidatorsTableOptions.pagination.pageSize
+        }
         placeholderData={{}}
         isLastPage={
-          totalPages === mockValidatorsTableOptions.pagination.pageSize
+          currentEraTotalPages ===
+          mockCurrentEraValidatorsTableOptions.pagination.pageSize
         }
       />,
     ),
@@ -52,38 +69,38 @@ describe('ValidatorsTable', () => {
   });
 
   it('should render a Rank', () => {
-    const rank = screen.getByTestId('rank');
-    expect(rank).toHaveTextContent(
+    const rank = screen.getAllByTestId('rank');
+    expect(rank[0]).toHaveTextContent(
       mockCurrentEraValidators.validators[0].rank.toString(),
     );
   });
 
   it('should render a truncated Public Key', () => {
-    const publicKey = screen.getByTestId('truncated-public-key');
+    const publicKey = screen.getAllByTestId('truncated-public-key');
 
-    expect(publicKey).toHaveTextContent(
+    expect(publicKey[0]).toHaveTextContent(
       truncateHash(mockCurrentEraValidators.validators[0].publicKey),
     );
   });
 
   it('should render a Fee', () => {
-    const fee = screen.getByTestId('fee');
-    expect(fee).toHaveTextContent(
+    const fee = screen.getAllByTestId('fee');
+    expect(fee[0]).toHaveTextContent(
       mockCurrentEraValidators.validators[0].feePercentage.toString(),
     );
   });
 
   it('should render number of Delegators', () => {
-    const delegators = screen.getByTestId('delegators');
+    const delegators = screen.getAllByTestId('delegators');
 
-    expect(delegators).toHaveTextContent(
+    expect(delegators[0]).toHaveTextContent(
       mockCurrentEraValidators.validators[0].delegatorsCount.toString(),
     );
   });
 
   it('should render Total Stake for Current Era', () => {
-    const totalStake = screen.getByTestId('total-stake');
-    expect(totalStake).toHaveTextContent(
+    const totalStake = screen.getAllByTestId('total-stake');
+    expect(totalStake[0]).toHaveTextContent(
       standardizeNumber(
         (
           mockCurrentEraValidators.validators[0].totalStakeMotes /
@@ -94,8 +111,8 @@ describe('ValidatorsTable', () => {
   });
 
   it('should render Self Percentage', () => {
-    const selfPercentage = screen.getByTestId('self-percentage');
-    expect(selfPercentage).toHaveTextContent(
+    const selfPercentage = screen.getAllByTestId('self-percentage');
+    expect(selfPercentage[0]).toHaveTextContent(
       standardizePercentage(
         mockCurrentEraValidators.validators[0].selfPercentage,
       ).toString(),
@@ -103,8 +120,8 @@ describe('ValidatorsTable', () => {
   });
 
   it('should render Percentage of Network', () => {
-    const percentageOfNetwork = screen.getByTestId('percentage-of-network');
-    expect(percentageOfNetwork).toHaveTextContent(
+    const percentageOfNetwork = screen.getAllByTestId('percentage-of-network');
+    expect(percentageOfNetwork[0]).toHaveTextContent(
       standardizePercentage(
         mockCurrentEraValidators.validators[0].percentageOfNetwork,
       ).toString(),
@@ -114,20 +131,25 @@ describe('ValidatorsTable', () => {
   it('should render a loading ValidatorsTable', () => {
     render(
       <Table
-        header={mockValidatorsTableHeader}
+        header={mockCurrentEraValidatorsTableHeader}
         columns={mockValidatorsTableColumns}
         data={mockCurrentEraValidators.validators}
-        footer={mockValidatorsTableFooter}
+        footer={mockCurrentEraValidatorsTableFooter}
+        currentPageSize={
+          mockCurrentEraValidatorsTableOptions.pagination.pageSize
+        }
         tableBodyLoading
-        currentPageSize={mockValidatorsTableOptions.pagination.pageSize}
         placeholderData={{}}
         isLastPage={
-          totalPages === mockValidatorsTableOptions.pagination.pageSize
+          currentEraTotalPages ===
+          mockCurrentEraValidatorsTableOptions.pagination.pageSize
         }
       />,
     );
     const skeletonLoader = screen.getAllByTestId('skeleton-loader');
-    expect(skeletonLoader).toHaveLength(7);
+    expect(skeletonLoader).toHaveLength(
+      mockCurrentEraValidators.validators.length * totalColumns,
+    );
   });
 });
 
@@ -146,18 +168,21 @@ describe('Next Era', () => {
           Next Era {status.latestEraId}
         </EraToggleButton>
         <Table
-          header={mockValidatorsTableHeader}
+          header={mockNextEraValidatorsTableHeader}
           columns={mockValidatorsTableColumns}
           data={
             isCurrentEra
               ? mockCurrentEraValidators.validators
-              : mockNextEraValidators.validators
+              : mockNextEraValidators.nextEraValidators
           }
-          footer={mockValidatorsTableFooter}
-          currentPageSize={mockValidatorsTableOptions.pagination.pageSize}
+          footer={mockNextEraValidatorsTableFooter}
+          currentPageSize={
+            mockNextEraValidatorsTableOptions.pagination.pageSize
+          }
           placeholderData={{}}
           isLastPage={
-            totalPages === mockValidatorsTableOptions.pagination.pageSize
+            nexEraTotalPages ===
+            mockNextEraValidatorsTableOptions.pagination.pageSize
           }
         />
       </div>,
@@ -165,7 +190,7 @@ describe('Next Era', () => {
 
     const currentEraButton = screen.getByText('Current Era 8888');
     const nextEraButton = screen.getByText('Next Era 8889');
-    const totalStake = screen.getByTestId('total-stake');
+    const totalStake = screen.getAllByTestId('total-stake');
 
     expect(currentEraButton).toBeInTheDocument();
     expect(nextEraButton).toBeInTheDocument();
@@ -174,11 +199,12 @@ describe('Next Era', () => {
 
     expect(onClickMock).toBeCalledTimes(1);
     expect(onClickMock).toReturnWith(true);
-    expect(totalStake).toHaveTextContent(
+    expect(totalStake[0]).toHaveTextContent(
       standardizeNumber(
-        (mockNextEraValidators.validators[0].totalStakeMotes / 10 ** 9).toFixed(
-          0,
-        ),
+        (
+          mockNextEraValidators.nextEraValidators[0].totalStakeMotes /
+          10 ** 9
+        ).toFixed(0),
       ).toString(),
     );
   });

--- a/app/src/components/tables/ValidatorsTable/ValidatorsTable.tsx
+++ b/app/src/components/tables/ValidatorsTable/ValidatorsTable.tsx
@@ -28,7 +28,6 @@ import { SelectOptions } from 'src/components/layout/Header/Partials';
 import { DEFAULT_SECONDARY_FONT_FAMILIES } from 'src/constants';
 import { standardizePercentage } from 'src/utils/standardize-percentage';
 import { StyledCopyToClipboard } from 'src/components/utility';
-import { useTheme } from '@emotion/react';
 import { NumberedPagination } from '../Pagination';
 
 const validSortableValidatorsColumns = [
@@ -44,8 +43,6 @@ export const ValidatorsTable: React.FC = () => {
   const [isCurrentEra, setIsCurrentEra] = useState(true);
 
   const { t } = useTranslation();
-
-  const { type: themeType } = useTheme();
 
   const dispatch = useAppDispatch();
 

--- a/app/src/components/tables/ValidatorsTable/ValidatorsTable.tsx
+++ b/app/src/components/tables/ValidatorsTable/ValidatorsTable.tsx
@@ -39,7 +39,7 @@ const validSortableValidatorsColumns = [
   'percentageOfNetwork',
 ];
 
-export const ValidatorTable: React.FC = () => {
+export const ValidatorsTable: React.FC = () => {
   const [isTableLoading, setIsTableLoading] = useState(false);
   const [isCurrentEra, setIsCurrentEra] = useState(true);
 

--- a/app/src/components/tables/ValidatorsTable/ValidatorsTable.tsx
+++ b/app/src/components/tables/ValidatorsTable/ValidatorsTable.tsx
@@ -29,7 +29,6 @@ import { DEFAULT_SECONDARY_FONT_FAMILIES } from 'src/constants';
 import { standardizePercentage } from 'src/utils/standardize-percentage';
 import { StyledCopyToClipboard } from 'src/components/utility';
 import { useTheme } from '@emotion/react';
-import { darkTheme, lightTheme } from 'src/theme';
 import { NumberedPagination } from '../Pagination';
 
 const validSortableValidatorsColumns = [
@@ -265,19 +264,6 @@ export const ValidatorsTable: React.FC = () => {
 
   return (
     <Table<ApiData.ValidatorsInfo>
-      theme={
-        themeType === 'light'
-          ? {
-              bgColor: `${lightTheme.background.primary}`,
-              borderColor: `${lightTheme.border}`,
-              color: `${lightTheme.text.primary}`,
-            }
-          : {
-              bgColor: `${darkTheme.background.primary}`,
-              borderColor: `${darkTheme.border}`,
-              color: `${darkTheme.text.primary}`,
-            }
-      }
       header={header}
       columns={columns}
       data={isCurrentEra ? currentEraValidators : nextEraValidators}
@@ -297,26 +283,12 @@ export const ValidatorsTable: React.FC = () => {
   );
 };
 
-// const StyledTable = styled(Table)<ApiData.ValidatorsInfo>`
-//   width: 100%;
-//   margin-bottom: 8rem;
-//   border-radius: 0.5rem;
-//   overflow-x: auto;
-//   max-width: calc(100vw - 5rem);
-//   margin: 0 auto;
-//   background-color: ${props => props.theme.background.primary};
-//   border: 3px solid ${props => props.theme.border};
-//   box-shadow: 0px 2px 7px ${props => props.theme.boxShadow};
-//   color: ${props => props.theme.text.primary};
-// `;
-
 const ValidatorTableHead = styled.div`
   display: flex;
   flex-direction: column;
   min-width: ${pxToRem(800)};
   justify-content: space-between;
   align-items: center;
-  /* background-color: ${props => props.theme.background.primary}; */
   color: ${props => props.theme.text.secondary};
 `;
 

--- a/app/src/components/tables/ValidatorsTable/ValidatorsTable.tsx
+++ b/app/src/components/tables/ValidatorsTable/ValidatorsTable.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from '@emotion/styled';
 import { ColumnDef, OnChangeFn, SortingState } from '@tanstack/react-table';
-import { Button, defaultTheme, pxToRem } from 'casper-ui-kit';
+import { Button, defaultTheme, pxToRem, Table } from 'casper-ui-kit';
 import {
   fetchCurrentEraValidatorStatus,
   fetchValidators,
@@ -28,7 +28,8 @@ import { SelectOptions } from 'src/components/layout/Header/Partials';
 import { DEFAULT_SECONDARY_FONT_FAMILIES } from 'src/constants';
 import { standardizePercentage } from 'src/utils/standardize-percentage';
 import { StyledCopyToClipboard } from 'src/components/utility';
-import { Table } from '../../base';
+import { useTheme } from '@emotion/react';
+import { darkTheme, lightTheme } from 'src/theme';
 import { NumberedPagination } from '../Pagination';
 
 const validSortableValidatorsColumns = [
@@ -44,6 +45,8 @@ export const ValidatorsTable: React.FC = () => {
   const [isCurrentEra, setIsCurrentEra] = useState(true);
 
   const { t } = useTranslation();
+
+  const { type: themeType } = useTheme();
 
   const dispatch = useAppDispatch();
 
@@ -262,6 +265,19 @@ export const ValidatorsTable: React.FC = () => {
 
   return (
     <Table<ApiData.ValidatorsInfo>
+      theme={
+        themeType === 'light'
+          ? {
+              bgColor: `${lightTheme.background.primary}`,
+              borderColor: `${lightTheme.border}`,
+              color: `${lightTheme.text.primary}`,
+            }
+          : {
+              bgColor: `${darkTheme.background.primary}`,
+              borderColor: `${darkTheme.border}`,
+              color: `${darkTheme.text.primary}`,
+            }
+      }
       header={header}
       columns={columns}
       data={isCurrentEra ? currentEraValidators : nextEraValidators}
@@ -281,12 +297,26 @@ export const ValidatorsTable: React.FC = () => {
   );
 };
 
+// const StyledTable = styled(Table)<ApiData.ValidatorsInfo>`
+//   width: 100%;
+//   margin-bottom: 8rem;
+//   border-radius: 0.5rem;
+//   overflow-x: auto;
+//   max-width: calc(100vw - 5rem);
+//   margin: 0 auto;
+//   background-color: ${props => props.theme.background.primary};
+//   border: 3px solid ${props => props.theme.border};
+//   box-shadow: 0px 2px 7px ${props => props.theme.boxShadow};
+//   color: ${props => props.theme.text.primary};
+// `;
+
 const ValidatorTableHead = styled.div`
   display: flex;
   flex-direction: column;
   min-width: ${pxToRem(800)};
   justify-content: space-between;
   align-items: center;
+  /* background-color: ${props => props.theme.background.primary}; */
   color: ${props => props.theme.text.secondary};
 `;
 

--- a/app/src/components/tables/ValidatorsTable/index.ts
+++ b/app/src/components/tables/ValidatorsTable/index.ts
@@ -1,0 +1,1 @@
+export { ValidatorsTable } from './ValidatorsTable';

--- a/app/src/components/tables/index.ts
+++ b/app/src/components/tables/index.ts
@@ -1,4 +1,4 @@
 export * from './BlockTable';
 export * from './Pagination';
-export * from './ValidatorTable';
+export * from './ValidatorsTable';
 export * from './PeersTable';

--- a/app/src/mocks/mock-peers-table.tsx
+++ b/app/src/mocks/mock-peers-table.tsx
@@ -8,14 +8,16 @@ import { setPeerTableOptions, updateValidatorPageNum } from 'src/store';
 export const getMockPeers = () => ({
   paginatedResult: [
     { nodeId: 'tls:9a2c..2889', address: '144.76.85.204:35000' },
-    { nodeId: 'tls:9a2c..2881', address: '144.76.85.205:35000' },
   ],
   totalPeers: 233,
 });
 
+const mockPeers = getMockPeers();
+const { totalPeers, paginatedResult } = mockPeers;
+
 export const mockPeersTableOptions: TableOptions = {
   pagination: {
-    pageSize: 1,
+    pageSize: paginatedResult.length,
     pageNum: 1,
   },
   sorting: {
@@ -33,7 +35,7 @@ const mockRowCountSelectOptions = [
 
 export const getMockPeersTableHeader = () => (
   <div data-testid="peers-table-header">
-    <div data-testid="total-peers">233 total rows</div>
+    <div data-testid="total-peers">`${totalPeers} total rows`</div>
     <NumberedPagination
       tableOptions={mockPeersTableOptions}
       setTableOptions={setPeerTableOptions}

--- a/app/src/mocks/mock-peers-table.tsx
+++ b/app/src/mocks/mock-peers-table.tsx
@@ -8,10 +8,10 @@ import { setPeerTableOptions, updateValidatorPageNum } from 'src/store';
 export const getMockPeers = () => ({
   paginatedResult: [
     { nodeId: 'tls:9a2c..2889', address: '144.76.85.204:35000' },
-    { nodeId: 'tls:9a2c..2889', address: '144.76.85.204:35000' },
-    { nodeId: 'tls:9a2c..2889', address: '144.76.85.204:35000' },
-    { nodeId: 'tls:9a2c..2889', address: '144.76.85.204:35000' },
-    { nodeId: 'tls:9a2c..2889', address: '144.76.85.204:35000' },
+    { nodeId: 'tls:0152..1130', address: '65.108.127.242:35000' },
+    { nodeId: 'tls:026d..121c', address: '3.141.144.131:35000' },
+    { nodeId: 'tls:0309..c08f', address: '82.53.3.172:33216' },
+    { nodeId: 'tls:0427..d740', address: '54.177.85.235:35000' },
   ],
   totalPeers: 233,
 });

--- a/app/src/mocks/mock-peers-table.tsx
+++ b/app/src/mocks/mock-peers-table.tsx
@@ -12,6 +12,11 @@ export const getMockPeers = () => ({
     { nodeId: 'tls:026d..121c', address: '3.141.144.131:35000' },
     { nodeId: 'tls:0309..c08f', address: '82.53.3.172:33216' },
     { nodeId: 'tls:0427..d740', address: '54.177.85.235:35000' },
+    { nodeId: 'tls:9a2c..2888', address: '144.76.85.204:35000' },
+    { nodeId: 'tls:0152..1137', address: '66.108.127.242:35000' },
+    { nodeId: 'tls:026d..121a', address: '3.241.144.131:35000' },
+    { nodeId: 'tls:0309..c08t', address: '82.63.3.172:33216' },
+    { nodeId: 'tls:0427..d744', address: '54.187.85.235:35000' },
   ],
   totalPeers: 233,
 });

--- a/app/src/mocks/mock-peers-table.tsx
+++ b/app/src/mocks/mock-peers-table.tsx
@@ -8,6 +8,10 @@ import { setPeerTableOptions, updateValidatorPageNum } from 'src/store';
 export const getMockPeers = () => ({
   paginatedResult: [
     { nodeId: 'tls:9a2c..2889', address: '144.76.85.204:35000' },
+    { nodeId: 'tls:9a2c..2889', address: '144.76.85.204:35000' },
+    { nodeId: 'tls:9a2c..2889', address: '144.76.85.204:35000' },
+    { nodeId: 'tls:9a2c..2889', address: '144.76.85.204:35000' },
+    { nodeId: 'tls:9a2c..2889', address: '144.76.85.204:35000' },
   ],
   totalPeers: 233,
 });

--- a/app/src/mocks/mock-peers-table.tsx
+++ b/app/src/mocks/mock-peers-table.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { ColumnDef } from '@tanstack/react-table';
+import { ApiData } from 'src/api/types';
+import { NumberedPagination } from 'src/components';
+import { TableOptions } from 'src/store/types';
+import { setPeerTableOptions, updateValidatorPageNum } from 'src/store';
+
+export const getMockPeers = () => ({
+  paginatedResult: [
+    { nodeId: 'tls:9a2c..2889', address: '144.76.85.204:35000' },
+    { nodeId: 'tls:9a2c..2881', address: '144.76.85.205:35000' },
+  ],
+  totalPeers: 233,
+});
+
+export const mockPeersTableOptions: TableOptions = {
+  pagination: {
+    pageSize: 10,
+    pageNum: 1,
+  },
+  sorting: {
+    sortBy: '',
+    order: 'desc',
+  },
+};
+
+const mockRowCountSelectOptions = [
+  {
+    value: 'string',
+    label: 'string',
+  },
+];
+
+export const getMockPeersTableHeader = () => (
+  <div data-testid="peers-table-header">
+    <div data-testid="total-peers">233</div>
+    <NumberedPagination
+      tableOptions={mockPeersTableOptions}
+      setTableOptions={setPeerTableOptions}
+      rowCountSelectOptions={mockRowCountSelectOptions}
+      setIsTableLoading={jest.fn}
+      totalPages={1}
+      updatePageNum={updateValidatorPageNum}
+    />
+    ;
+  </div>
+);
+
+export const getMockPeersTableFooter = () => (
+  <div data-testid="peers-table-footer">
+    <NumberedPagination
+      tableOptions={mockPeersTableOptions}
+      setTableOptions={setPeerTableOptions}
+      rowCountSelectOptions={mockRowCountSelectOptions}
+      setIsTableLoading={jest.fn}
+      totalPages={1}
+      updatePageNum={updateValidatorPageNum}
+    />
+  </div>
+);
+
+export const mockPeersTableColumns: ColumnDef<ApiData.Peer>[] = [
+  {
+    header: 'Node Id',
+    accessorKey: 'nodeId',
+    enableSorting: false,
+    size: 250,
+  },
+  {
+    header: 'Address',
+    accessorKey: 'address',
+    enableSorting: false,
+    size: 250,
+  },
+];

--- a/app/src/mocks/mock-peers-table.tsx
+++ b/app/src/mocks/mock-peers-table.tsx
@@ -15,7 +15,7 @@ export const getMockPeers = () => ({
 
 export const mockPeersTableOptions: TableOptions = {
   pagination: {
-    pageSize: 10,
+    pageSize: 1,
     pageNum: 1,
   },
   sorting: {
@@ -33,7 +33,7 @@ const mockRowCountSelectOptions = [
 
 export const getMockPeersTableHeader = () => (
   <div data-testid="peers-table-header">
-    <div data-testid="total-peers">233</div>
+    <div data-testid="total-peers">233 total rows</div>
     <NumberedPagination
       tableOptions={mockPeersTableOptions}
       setTableOptions={setPeerTableOptions}
@@ -65,11 +65,17 @@ export const mockPeersTableColumns: ColumnDef<ApiData.Peer>[] = [
     accessorKey: 'nodeId',
     enableSorting: false,
     size: 250,
+    cell: ({ getValue }) => (
+      <div data-testid="node-id">{getValue<string>()}</div>
+    ),
   },
   {
     header: 'Address',
     accessorKey: 'address',
     enableSorting: false,
     size: 250,
+    cell: ({ getValue }) => (
+      <div data-testid="address">{getValue<string>()}</div>
+    ),
   },
 ];

--- a/app/src/mocks/mock-peers-table.tsx
+++ b/app/src/mocks/mock-peers-table.tsx
@@ -17,6 +17,16 @@ export const getMockPeers = () => ({
     { nodeId: 'tls:026d..121a', address: '3.241.144.131:35000' },
     { nodeId: 'tls:0309..c08t', address: '82.63.3.172:33216' },
     { nodeId: 'tls:0427..d744', address: '54.187.85.235:35000' },
+    { nodeId: 'tls:9a2c..2889', address: '144.76.85.204:35000' },
+    { nodeId: 'tls:0152..1130', address: '65.108.127.242:35000' },
+    { nodeId: 'tls:026d..121c', address: '3.141.144.131:35000' },
+    { nodeId: 'tls:0309..c08f', address: '82.53.3.172:33216' },
+    { nodeId: 'tls:0427..d740', address: '54.177.85.235:35000' },
+    { nodeId: 'tls:9a2c..2888', address: '144.76.85.204:35000' },
+    { nodeId: 'tls:0152..1137', address: '66.108.127.242:35000' },
+    { nodeId: 'tls:026d..121a', address: '3.241.144.131:35000' },
+    { nodeId: 'tls:0309..c08t', address: '82.63.3.172:33216' },
+    { nodeId: 'tls:0427..d744', address: '54.187.85.235:35000' },
   ],
   totalPeers: 233,
 });
@@ -50,7 +60,7 @@ export const getMockPeersTableHeader = () => (
       setTableOptions={setPeerTableOptions}
       rowCountSelectOptions={mockRowCountSelectOptions}
       setIsTableLoading={jest.fn}
-      totalPages={1}
+      totalPages={2}
       updatePageNum={updateValidatorPageNum}
     />
     ;

--- a/app/src/mocks/mock-validator-table.tsx
+++ b/app/src/mocks/mock-validator-table.tsx
@@ -25,7 +25,7 @@ export const getMockCurrentEraValidators = () => ({
 });
 
 export const getMockNextEraValidators = () => ({
-  validators: [
+  nextEraValidators: [
     {
       publicKey:
         '015692c70f62a5227b4af46b90f03b0966725d8101215dfcf395445459e5ba2fad',
@@ -40,9 +40,26 @@ export const getMockNextEraValidators = () => ({
   status: { validatorsCount: 100, bidsCount: 110, latestEraId: 8889 },
 });
 
-export const mockValidatorsTableOptions: TableOptions = {
+const mockCurrentEraValidators = getMockCurrentEraValidators();
+const { validators } = mockCurrentEraValidators;
+
+export const mockCurrentEraValidatorsTableOptions: TableOptions = {
   pagination: {
-    pageSize: 10,
+    pageSize: validators.length,
+    pageNum: 1,
+  },
+  sorting: {
+    sortBy: '',
+    order: 'desc',
+  },
+};
+
+const mockNextEraValidators = getMockNextEraValidators();
+const { nextEraValidators } = mockNextEraValidators;
+
+export const mockNextEraValidatorsTableOptions: TableOptions = {
+  pagination: {
+    pageSize: nextEraValidators.length,
     pageNum: 1,
   },
   sorting: {
@@ -58,10 +75,10 @@ const mockRowCountSelectOptions = [
   },
 ];
 
-export const getMockValidatorsTableHeader = () => (
+export const getMockCurrentEraValidatorsTableHeader = () => (
   <div data-testid="validators-table-header">
     <NumberedPagination
-      tableOptions={mockValidatorsTableOptions}
+      tableOptions={mockCurrentEraValidatorsTableOptions}
       setTableOptions={setValidatorTableOptions}
       rowCountSelectOptions={mockRowCountSelectOptions}
       setIsTableLoading={jest.fn}
@@ -72,10 +89,38 @@ export const getMockValidatorsTableHeader = () => (
   </div>
 );
 
-export const getMockValidatorsTableFooter = () => (
+export const getMockCurrentEraValidatorsTableFooter = () => (
   <div data-testid="validators-table-footer">
     <NumberedPagination
-      tableOptions={mockValidatorsTableOptions}
+      tableOptions={mockCurrentEraValidatorsTableOptions}
+      setTableOptions={setValidatorTableOptions}
+      rowCountSelectOptions={mockRowCountSelectOptions}
+      setIsTableLoading={jest.fn}
+      totalPages={1}
+      updatePageNum={updateValidatorPageNum}
+    />
+    ;
+  </div>
+);
+
+export const getMockNextEraValidatorsTableHeader = () => (
+  <div data-testid="validators-table-header">
+    <NumberedPagination
+      tableOptions={mockNextEraValidatorsTableOptions}
+      setTableOptions={setValidatorTableOptions}
+      rowCountSelectOptions={mockRowCountSelectOptions}
+      setIsTableLoading={jest.fn}
+      totalPages={1}
+      updatePageNum={updateValidatorPageNum}
+    />
+    ;
+  </div>
+);
+
+export const getMockNextEraValidatorsTableFooter = () => (
+  <div data-testid="validators-table-footer">
+    <NumberedPagination
+      tableOptions={mockNextEraValidatorsTableOptions}
       setTableOptions={setValidatorTableOptions}
       rowCountSelectOptions={mockRowCountSelectOptions}
       setIsTableLoading={jest.fn}

--- a/app/src/pages/Validators.tsx
+++ b/app/src/pages/Validators.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { PageTableHeader } from '../components/layout/Header/Header.styled';
-import { PageHead, PageWrapper, ValidatorTable } from '../components';
+import { PageHead, PageWrapper, ValidatorsTable } from '../components';
 
 export const Validators: React.FC = () => {
   const { t } = useTranslation();
@@ -12,7 +12,7 @@ export const Validators: React.FC = () => {
     <PageWrapper isLoading={false}>
       <PageHead pageTitle={pageTitle} />
       <PageTableHeader>{t('validators')}</PageTableHeader>
-      <ValidatorTable />
+      <ValidatorsTable />
     </PageWrapper>
   );
 };


### PR DESCRIPTION
🔥 Summary
Adds PeersTable tests https://github.com/casper-network/casper-blockexplorer-frontend/issues/413

Also, updates ValidatorsTable test to handle dynamic mock data.