### PR TITLE
remove env name prod from variable name

### DIFF
--- a/.cicd/manifests/config-map.yaml
+++ b/.cicd/manifests/config-map.yaml
@@ -13,5 +13,5 @@ data:
   ORG_FONT_URL: {{or .Values.orgFontUrl "" | quote}}
   ORG_PRIMARY_FONT_NAME: {{or .Values.orgPrimaryFontName "" | quote}}
   ORG_SECONDARY_FONT_NAME: {{or .Values.orgSecondaryFontName "" | quote}}
-  LIGHT_THEME: {{or .Values.prodLightTheme "" | quote}}
-  DARK_THEME: {{or .Values.prodDarkTheme "" | quote}}
+  LIGHT_THEME: {{or .Values.lightTheme "" | quote}}
+  DARK_THEME: {{or .Values.darkTheme "" | quote}}


### PR DESCRIPTION
### 🔥 Summary

Env Vars are per-environment, so should not include an environment name

### 📹 Video

### 😤 Problem / Goals
-

### 🤓 Solution
-

### 🗒️ Additional Notes
-
