### PR TITLE
requires an npm install to have cypress in the image

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -7,6 +7,7 @@ COPY ./test /app
 
 WORKDIR /app
 
+RUN npm install
 RUN ./node_modules/.bin/cypress install
 
 RUN npx cypress verify


### PR DESCRIPTION
### 🔥 Summary

without npm install, get this error

8 0.141 /bin/sh: 1: ./node_modules/.bin/cypress: not found



-
