### PR TITLE
feat: add deploys info card to home

### DIFF
--- a/app/src/components/layout/Home/DeployInfo/DeploysInfo.tsx
+++ b/app/src/components/layout/Home/DeployInfo/DeploysInfo.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import styled from '@emotion/styled';
 import { useTranslation } from 'react-i18next';
-import { defaultTheme, Icon } from 'casper-ui-kit';
+import { Icon } from 'casper-ui-kit';
+import { useTheme } from '@emotion/react';
+import { darkTheme, lightTheme } from 'src/theme';
 import {
   IconH2Container,
   H2,
@@ -9,61 +10,54 @@ import {
   H3,
   H3Data,
   DataContext,
+  Header,
+  Details,
+  TextWrapper,
+  Info,
+  Card,
 } from '../HomeComponents.styled';
 
 export const DeploysInfo: React.FC = () => {
   const { t } = useTranslation();
+  const { type: themeType } = useTheme();
 
   return (
-    <DeploysInfoDisplay data-cy="deploys-info">
-      <DeploysHeader>
+    <Card data-cy="deploys-info">
+      <Header>
         <IconH2Container>
-          <Icon icon="DeployIcon" height={25} />
+          {
+            <Icon
+              icon="DeployIcon"
+              width={49}
+              height={25}
+              color="none"
+              stroke={
+                themeType === 'light'
+                  ? lightTheme.text.primary
+                  : darkTheme.text.primary
+              }
+            />
+          }
+
           <H2>{t('deploys')}</H2>
         </IconH2Container>
         <PageLink to="/deploys">{t('view-all')}</PageLink>
-      </DeploysHeader>
-      <DeployDetails>
-        <H3>{t('total-deploys')}</H3>
-        <H3Data>{t('n/a')}</H3Data>
-        <DataContext>{t('n/a')}</DataContext>
-        <H3>{t('today')}</H3>
-        <H3Data>{t('n/a')}</H3Data>
-      </DeployDetails>
-    </DeploysInfoDisplay>
+      </Header>
+      <Details>
+        <Info>
+          <TextWrapper>
+            <H3>{t('total-deploys')}</H3>
+          </TextWrapper>
+          <H3Data>{t('n/a')}</H3Data>
+          <DataContext>{t('n/a')}</DataContext>
+        </Info>
+        <Info>
+          <TextWrapper>
+            <H3>{t('today')}</H3>
+          </TextWrapper>
+          <H3Data>{t('n/a')}</H3Data>
+        </Info>
+      </Details>
+    </Card>
   );
 };
-
-const DeploysInfoDisplay = styled.section`
-  display: none;
-  border-radius: 0.5rem;
-  background: ${props => props.theme.background.primary};
-  border: 0.063rem solid ${props => props.theme.background.hover};
-  box-shadow: 0px 2px 7px ${props => props.theme.boxShadow};
-  padding-bottom: 1.5rem;
-
-  @media (min-width: ${defaultTheme.breakpoints.md}) {
-    min-width: 44.5%;
-  }
-
-  @media (min-width: ${defaultTheme.breakpoints.lg}) {
-    min-width: 40%;
-  }
-`;
-
-const DeploysHeader = styled.header`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1.15rem 2rem;
-`;
-
-const DeployDetails = styled.section`
-  display: flex;
-  flex-direction: column;
-  justify-content: start;
-  border-top: 0.094rem solid ${props => props.theme.background.secondary};
-  padding: 0 0;
-  margin: 0 2rem;
-`;


### PR DESCRIPTION
### 🔥 Summary
- Add deploys info card to home page
- Temp info until deploys endpoint is updated

<img width="1726" alt="Screenshot 2023-07-19 at 3 24 39 PM" src="https://github.com/casper-network/casper-blockexplorer-frontend/assets/76149236/cdb0f241-f82f-4a55-947f-27818c33915c">
